### PR TITLE
[SL-94] chore: 초기 필요한 설정 파일 추가

### DIFF
--- a/src/main/java/com/sds/actlongs/config/AwsConfig.java
+++ b/src/main/java/com/sds/actlongs/config/AwsConfig.java
@@ -1,0 +1,32 @@
+package com.sds.actlongs.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsConfig {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+			.build();
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/config/JpaAuditingConfig.java
+++ b/src/main/java/com/sds/actlongs/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.sds.actlongs.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/sds/actlongs/config/SwaggerConfig.java
+++ b/src/main/java/com/sds/actlongs/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.sds.actlongs.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.useDefaultResponseMessages(false)
+			.apiInfo(apiInfo())
+			.select()
+			.apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+			.paths(PathSelectors.any())
+			.build();
+	}
+
+	private ApiInfo apiInfo() {
+		return new ApiInfoBuilder()
+			.title("Longs's API Docs")
+			.version("1.0")
+			.description("API 명세서")
+			.build();
+	}
+
+}


### PR DESCRIPTION
JpaAuditing, Swagger, AWS 관련 설정 파일을 추가했어요.

AwsConfig에 있는 비밀 key-value 들은 환경변수로 주입받아서 사용해요.
```java
	@Value("${cloud.aws.credentials.access-key}") // 얘랑
	private String accessKey;

	@Value("${cloud.aws.credentials.secret-key}") // 얘는 application.yml에서 주입받아요.
	private String secretKey;
```

```yml
cloud:
  aws:
    credentials:
      access-key: ${AWS_ACCESS_KEY} # 이렇게 생긴 애들은 환경변수로 주입받는다는 뜻이에요.
      secret-key: ${AWS_SECRET_KEY}
    s3:
      bucket: act-longs
    region:
      static: ap-northeast-2
    stack:
      auto: false
```

![image](https://github.com/sds-newbie-longs/longs-backend/assets/68049320/c5f2d4f6-466a-43b7-bd54-d671ffe02d9d)

1번 > Edit Configurations... 선택
2번 > Program Arguments 선택
3번 > --key=value --key2=value2 형식으로 추가
