### PR TITLE
공통 응답 모델 및 예외 핸들러 추가

### DIFF
--- a/longs-formatter.xml
+++ b/longs-formatter.xml
@@ -1,368 +1,368 @@
 <code_scheme name="longs-formatter" version="173">
-    <option name="FORMATTER_TAGS_ENABLED" value="true"/>
-    <JavaCodeStyleSettings>
-        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99"/>
-        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1"/>
-        <option name="IMPORT_LAYOUT_TABLE">
-            <value>
-                <emptyLine/>
-                <package name="" withSubpackages="true" static="true"/>
-                <emptyLine/>
-                <package name="java" withSubpackages="true" static="false"/>
-                <emptyLine/>
-                <package name="javax" withSubpackages="true" static="false"/>
-                <emptyLine/>
-                <package name="org" withSubpackages="true" static="false"/>
-                <emptyLine/>
-                <package name="net" withSubpackages="true" static="false"/>
-                <emptyLine/>
-                <package name="com.sds.actlongs" withSubpackages="true" static="false"/>
-                <emptyLine/>
-                <package name="" withSubpackages="true" static="false"/>
-                <emptyLine/>
-                <emptyLine/>
-            </value>
-        </option>
-        <option name="ENABLE_JAVADOC_FORMATTING" value="false"/>
-    </JavaCodeStyleSettings>
-    <codeStyleSettings language="JAVA">
-        <option name="RIGHT_MARGIN" value="120"/>
-        <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false"/>
-        <option name="LINE_COMMENT_ADD_SPACE" value="true"/>
-        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
-        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
-        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
-        <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
-        <option name="BLANK_LINES_BEFORE_CLASS_END" value="1"/>
-        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
-        <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
-        <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
-        <option name="CALL_PARAMETERS_WRAP" value="1"/>
-        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
-        <option name="EXTENDS_LIST_WRAP" value="1"/>
-        <option name="THROWS_LIST_WRAP" value="5"/>
-        <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
-        <option name="METHOD_CALL_CHAIN_WRAP" value="5"/>
-        <option name="BINARY_OPERATION_WRAP" value="1"/>
-        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
-        <option name="TERNARY_OPERATION_WRAP" value="1"/>
-        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
-        <indentOptions>
-            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
-            <option name="USE_TAB_CHARACTER" value="true"/>
-        </indentOptions>
-        <arrangement>
-            <rules>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PUBLIC>true</PUBLIC>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PROTECTED>true</PROTECTED>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PRIVATE>true</PRIVATE>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PUBLIC>true</PUBLIC>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PROTECTED>true</PROTECTED>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PRIVATE>true</PRIVATE>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PUBLIC>true</PUBLIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PROTECTED>true</PROTECTED>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <FINAL>true</FINAL>
-                                <PRIVATE>true</PRIVATE>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PUBLIC>true</PUBLIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PROTECTED>true</PROTECTED>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <FIELD>true</FIELD>
-                                <PRIVATE>true</PRIVATE>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <FIELD>true</FIELD>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <CONSTRUCTOR>true</CONSTRUCTOR>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <METHOD>true</METHOD>
-                                <PUBLIC>true</PUBLIC>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <METHOD>true</METHOD>
-                                <PROTECTED>true</PROTECTED>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <METHOD>true</METHOD>
-                                <PRIVATE>true</PRIVATE>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <METHOD>true</METHOD>
-                                <PUBLIC>true</PUBLIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <METHOD>true</METHOD>
-                                <PROTECTED>true</PROTECTED>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <METHOD>true</METHOD>
-                                <PRIVATE>true</PRIVATE>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <METHOD>true</METHOD>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <ENUM>true</ENUM>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <INTERFACE>true</INTERFACE>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <AND>
-                                <CLASS>true</CLASS>
-                                <STATIC>true</STATIC>
-                            </AND>
-                        </match>
-                    </rule>
-                </section>
-                <section>
-                    <rule>
-                        <match>
-                            <CLASS>true</CLASS>
-                        </match>
-                    </rule>
-                </section>
-            </rules>
-        </arrangement>
-    </codeStyleSettings>
+  <option name="FORMATTER_TAGS_ENABLED" value="true" />
+  <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1" />
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <emptyLine />
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="java" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="org" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="net" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="com.sds.actlongs" withSubpackages="true" static="false" />
+        <emptyLine />
+        <emptyLine />
+      </value>
+    </option>
+    <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
+  </JavaCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+    <option name="BLANK_LINES_BEFORE_CLASS_END" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="5" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="true" />
+    </indentOptions>
+    <arrangement>
+      <rules>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PUBLIC>true</PUBLIC>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PROTECTED>true</PROTECTED>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PRIVATE>true</PRIVATE>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PUBLIC>true</PUBLIC>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PROTECTED>true</PROTECTED>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PRIVATE>true</PRIVATE>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PUBLIC>true</PUBLIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PROTECTED>true</PROTECTED>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <FINAL>true</FINAL>
+                <PRIVATE>true</PRIVATE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PUBLIC>true</PUBLIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PROTECTED>true</PROTECTED>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <PRIVATE>true</PRIVATE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <FIELD>true</FIELD>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <CONSTRUCTOR>true</CONSTRUCTOR>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <PUBLIC>true</PUBLIC>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <PROTECTED>true</PROTECTED>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <PRIVATE>true</PRIVATE>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <PUBLIC>true</PUBLIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <PROTECTED>true</PROTECTED>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <PRIVATE>true</PRIVATE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <METHOD>true</METHOD>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <ENUM>true</ENUM>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <INTERFACE>true</INTERFACE>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <CLASS>true</CLASS>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <CLASS>true</CLASS>
+            </match>
+          </rule>
+        </section>
+      </rules>
+    </arrangement>
+  </codeStyleSettings>
 </code_scheme>

--- a/src/main/java/com/sds/actlongs/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sds/actlongs/advice/GlobalExceptionHandler.java
@@ -1,0 +1,131 @@
+package com.sds.actlongs.advice;
+
+import static com.sds.actlongs.model.ErrorCode.*;
+
+import javax.persistence.EntityNotFoundException;
+import javax.validation.ConstraintViolationException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+import com.sds.actlongs.exception.BusinessException;
+import com.sds.actlongs.model.ErrorCode;
+import com.sds.actlongs.model.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * <b>@Validated</b>에 의해 발생하는 <b>Bean Validation</b> 예외 처리<br>
+	 * @see <a href="https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4">@Valid vs @Validated</a>
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, e.getConstraintViolations());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * <b>@Valid</b>에 의해 발생하는 <b>Bean Validation</b> 예외 처리
+	 * @see <a href="https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4">@Valid vs @Validated</a>
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, e.getBindingResult());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * <b>@ModelAttribute</b> 바인딩 실패 예외 처리
+	 * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args">@ModelAttribute</a>
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, e.getBindingResult());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * <b>@RequestParam</b> or <b>@RequestPart</b> 필수 파라미터가 결여된 경우 예외 처리
+	 */
+	@ExceptionHandler({MissingServletRequestParameterException.class, MissingServletRequestPartException.class})
+	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, getRequestParam(e));
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * Controller method argument <b>타입</b>이 일치하지 않을 경우 예외 처리
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+		MethodArgumentTypeMismatchException e) {
+		final ErrorResponse response = ErrorResponse.of(e);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * <b>@RequestBody</b> 형식과 불일치하거나, <b>JSON</b> 형식에 맞지 않을 경우 예외 처리
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+		final ErrorResponse response = ErrorResponse.of(HTTP_MESSAGE_NOT_READABLE);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * 지원하지 않는 <b>HTTP method</b> 호출할 경우 예외 처리
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException e) {
+		final ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * 존재하지 않는 Entity를 조회하려는 경우 예외 처리
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+		final ErrorResponse response = ErrorResponse.of(ENTITY_NOT_FOUND);
+		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+	}
+
+	/**
+	 * <b>Business logic</b>에서 발생하는 모든 예외 처리
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		final ErrorCode errorCode = e.getErrorCode();
+		final ErrorResponse response = ErrorResponse.of(errorCode, e.getErrors());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * 위에 해당하지 않는 모든 예외 처리
+	 */
+	@ExceptionHandler
+	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+		final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	private String getRequestParam(Exception e) {
+		if (e instanceof MissingServletRequestParameterException) {
+			return ((MissingServletRequestParameterException)e).getParameterName();
+		} else {
+			return ((MissingServletRequestPartException)e).getRequestPartName();
+		}
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/sds/actlongs/advice/GlobalExceptionHandler.java
@@ -29,8 +29,8 @@ public class GlobalExceptionHandler {
 	 * @see <a href="https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4">@Valid vs @Validated</a>
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, e.getConstraintViolations());
+	protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException exception) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, exception.getConstraintViolations());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -39,8 +39,9 @@ public class GlobalExceptionHandler {
 	 * @see <a href="https://medium.com/javarevisited/are-you-using-valid-and-validated-annotations-wrong-b4a35ac1bca4">@Valid vs @Validated</a>
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, e.getBindingResult());
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException exception) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, exception.getBindingResult());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -49,8 +50,8 @@ public class GlobalExceptionHandler {
 	 * @see <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args">@ModelAttribute</a>
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, e.getBindingResult());
+	protected ResponseEntity<ErrorResponse> handleBindException(BindException exception) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, exception.getBindingResult());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -58,8 +59,8 @@ public class GlobalExceptionHandler {
 	 * <b>@RequestParam</b> or <b>@RequestPart</b> 필수 파라미터가 결여된 경우 예외 처리
 	 */
 	@ExceptionHandler({MissingServletRequestParameterException.class, MissingServletRequestPartException.class})
-	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
-		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, getRequestParam(e));
+	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception exception) {
+		final ErrorResponse response = ErrorResponse.of(INPUT_VALUE_INVALID, getRequestParam(exception));
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -68,8 +69,8 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
-		MethodArgumentTypeMismatchException e) {
-		final ErrorResponse response = ErrorResponse.of(e);
+		MethodArgumentTypeMismatchException exception) {
+		final ErrorResponse response = ErrorResponse.of(exception);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -77,7 +78,8 @@ public class GlobalExceptionHandler {
 	 * <b>@RequestBody</b> 형식과 불일치하거나, <b>JSON</b> 형식에 맞지 않을 경우 예외 처리
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException exception) {
 		final ErrorResponse response = ErrorResponse.of(HTTP_MESSAGE_NOT_READABLE);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
@@ -87,7 +89,7 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler
 	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
-		HttpRequestMethodNotSupportedException e) {
+		HttpRequestMethodNotSupportedException exception) {
 		final ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
@@ -96,7 +98,7 @@ public class GlobalExceptionHandler {
 	 * 존재하지 않는 Entity를 조회하려는 경우 예외 처리
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+	protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException exception) {
 		final ErrorResponse response = ErrorResponse.of(ENTITY_NOT_FOUND);
 		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
 	}
@@ -105,9 +107,9 @@ public class GlobalExceptionHandler {
 	 * <b>Business logic</b>에서 발생하는 모든 예외 처리
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
-		final ErrorCode errorCode = e.getErrorCode();
-		final ErrorResponse response = ErrorResponse.of(errorCode, e.getErrors());
+	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
+		final ErrorCode errorCode = exception.getErrorCode();
+		final ErrorResponse response = ErrorResponse.of(errorCode, exception.getErrors());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
@@ -115,16 +117,16 @@ public class GlobalExceptionHandler {
 	 * 위에 해당하지 않는 모든 예외 처리
 	 */
 	@ExceptionHandler
-	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+	protected ResponseEntity<ErrorResponse> handleException(Exception exception) {
 		final ErrorResponse response = ErrorResponse.of(INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
-	private String getRequestParam(Exception e) {
-		if (e instanceof MissingServletRequestParameterException) {
-			return ((MissingServletRequestParameterException)e).getParameterName();
+	private String getRequestParam(Exception exception) {
+		if (exception instanceof MissingServletRequestParameterException) {
+			return ((MissingServletRequestParameterException)exception).getParameterName();
 		} else {
-			return ((MissingServletRequestPartException)e).getRequestPartName();
+			return ((MissingServletRequestPartException)exception).getRequestPartName();
 		}
 	}
 

--- a/src/main/java/com/sds/actlongs/exception/BusinessException.java
+++ b/src/main/java/com/sds/actlongs/exception/BusinessException.java
@@ -1,0 +1,29 @@
+package com.sds.actlongs.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sds.actlongs.model.ErrorCode;
+import com.sds.actlongs.model.ErrorResponse.FieldError;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final List<FieldError> errors;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.errors = new ArrayList<>();
+	}
+
+	public BusinessException(ErrorCode errorCode, List<FieldError> errors) {
+		super(errorCode.getMessage());
+		this.errors = errors;
+		this.errorCode = errorCode;
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/exception/BusinessException.java
+++ b/src/main/java/com/sds/actlongs/exception/BusinessException.java
@@ -3,10 +3,10 @@ package com.sds.actlongs.exception;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Getter;
+
 import com.sds.actlongs.model.ErrorCode;
 import com.sds.actlongs.model.ErrorResponse.FieldError;
-
-import lombok.Getter;
 
 @Getter
 public abstract class BusinessException extends RuntimeException {

--- a/src/main/java/com/sds/actlongs/model/ErrorCode.java
+++ b/src/main/java/com/sds/actlongs/model/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.sds.actlongs.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	// Global
+	INTERNAL_SERVER_ERROR(500, "E-G001", "내부 서버 오류입니다."),
+	INPUT_VALUE_INVALID(400, "E-G002", "입력 값이 유효하지 않습니다."),
+	INPUT_TYPE_INVALID(400, "E-G003", "입력 타입이 유효하지 않습니다."),
+	METHOD_NOT_ALLOWED(405, "E-G004", "허용되지 않은 HTTP method 입니다."),
+	HTTP_MESSAGE_NOT_READABLE(400, "E-G005", "HTTP Request Body 형식이 올바르지 않습니다."),
+	REQUEST_PARAMETER_MISSING(400, "E-G006", "요청 파라미터는 필수입니다."),
+	REQUEST_HEADER_MISSING(400, "E-G007", "요청 헤더는 필수입니다.");
+
+	private final int status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sds/actlongs/model/ErrorCode.java
+++ b/src/main/java/com/sds/actlongs/model/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
 	METHOD_NOT_ALLOWED(405, "E-G004", "허용되지 않은 HTTP method 입니다."),
 	HTTP_MESSAGE_NOT_READABLE(400, "E-G005", "HTTP Request Body 형식이 올바르지 않습니다."),
 	REQUEST_PARAMETER_MISSING(400, "E-G006", "요청 파라미터는 필수입니다."),
-	REQUEST_HEADER_MISSING(400, "E-G007", "요청 헤더는 필수입니다.");
+	REQUEST_HEADER_MISSING(400, "E-G007", "요청 헤더는 필수입니다."),
+	ENTITY_NOT_FOUND(404, "E-G008", "존재하지 않는 Entity입니다.");
 
 	private final int status;
 	private final String code;

--- a/src/main/java/com/sds/actlongs/model/ErrorResponse.java
+++ b/src/main/java/com/sds/actlongs/model/ErrorResponse.java
@@ -1,0 +1,140 @@
+package com.sds.actlongs.model;
+
+import static com.sds.actlongs.model.ErrorCode.*;
+import static com.sds.actlongs.util.Constants.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ErrorResponse {
+
+	@ApiModelProperty(value = "HTTP 상태 코드", example = "400")
+	private int status;
+	@ApiModelProperty(value = "Business 상태 코드", example = "E-G002")
+	private String code;
+	@ApiModelProperty(value = "에러 메세지", example = "입력 값이 유효하지 않습니다.")
+	private String message;
+	@ApiModelProperty(value = "에러 목록")
+	private List<FieldError> errors;
+
+	private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+		this.message = code.getMessage();
+		this.status = code.getStatus();
+		this.errors = errors;
+		this.code = code.getCode();
+	}
+
+	private ErrorResponse(final ErrorCode code) {
+		this.message = code.getMessage();
+		this.status = code.getStatus();
+		this.code = code.getCode();
+		this.errors = new ArrayList<>();
+	}
+
+	private ErrorResponse(final int status, final String code, final String message, final List<FieldError> errors) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+		this.errors = errors;
+	}
+
+	public static ErrorResponse of(final int status, final String code, final String message,
+		final List<FieldError> errors) {
+		return new ErrorResponse(status, code, message, errors);
+	}
+
+	public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+		return new ErrorResponse(code, FieldError.of(bindingResult));
+	}
+
+	public static ErrorResponse of(final ErrorCode code, final Set<ConstraintViolation<?>> constraintViolations) {
+		return new ErrorResponse(code, FieldError.of(constraintViolations));
+	}
+
+	public static ErrorResponse of(final ErrorCode code, final String missingParameterName) {
+		return new ErrorResponse(code,
+			FieldError.of(missingParameterName, EMPTY, REQUEST_PARAMETER_MISSING.getMessage()));
+	}
+
+	public static ErrorResponse of(final ErrorCode code) {
+		return new ErrorResponse(code);
+	}
+
+	public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+		return new ErrorResponse(code, errors);
+	}
+
+	public static ErrorResponse of(MethodArgumentTypeMismatchException exception) {
+		final String value = exception.getValue() == null ? EMPTY : exception.getValue().toString();
+		final List<FieldError> errors = FieldError.of(exception.getName(), value, exception.getErrorCode());
+		return new ErrorResponse(INPUT_TYPE_INVALID, errors);
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class FieldError {
+
+		@ApiModelProperty(value = "에러 필드", example = "name")
+		private String field;
+		@ApiModelProperty(value = "에러 값", example = "이름을길게만들면유효한이름이아니라서사용할수없어요")
+		private String value;
+		@ApiModelProperty(value = "에러 이유", example = "\"^[A-Za-z\\d]{5,20}$\"와 일치해야 합니다")
+		private String reason;
+
+		public FieldError(final String field, final String value, final String reason) {
+			this.field = field;
+			this.value = value;
+			this.reason = reason;
+		}
+
+		public static List<FieldError> of(final String field, final String value, final String reason) {
+			final List<FieldError> fieldErrors = new ArrayList<>();
+			fieldErrors.add(new FieldError(field, value, reason));
+			return fieldErrors;
+		}
+
+		public static List<FieldError> of(final String field, final String value, final ErrorCode errorCode) {
+			final List<FieldError> fieldErrors = new ArrayList<>();
+			fieldErrors.add(new FieldError(field, value, errorCode.getMessage()));
+			return fieldErrors;
+		}
+
+		private static List<FieldError> of(final BindingResult bindingResult) {
+			final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+			return fieldErrors.stream()
+				.map(error -> new FieldError(
+					error.getField(), error.getRejectedValue() == null ? EMPTY : error.getRejectedValue().toString(),
+					error.getDefaultMessage()))
+				.collect(Collectors.toList());
+		}
+
+		private static List<FieldError> of(final Set<ConstraintViolation<?>> constraintViolations) {
+			final List<ConstraintViolation<?>> lists = new ArrayList<>(constraintViolations);
+			return lists.stream()
+				.map(error -> {
+					final String invalidValue =
+						error.getInvalidValue() == null ? EMPTY : error.getInvalidValue().toString();
+					final int index = error.getPropertyPath().toString().indexOf(DOT);
+					final String propertyPath = error.getPropertyPath().toString().substring(index + 1);
+					return new FieldError(propertyPath, invalidValue, error.getMessage());
+				})
+				.collect(Collectors.toList());
+		}
+
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/model/ErrorResponse.java
+++ b/src/main/java/com/sds/actlongs/model/ErrorResponse.java
@@ -13,11 +13,13 @@ import javax.validation.ConstraintViolation;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@ApiModel(description = "응답 결과 공통 모델(예외)")
 @Getter
 @NoArgsConstructor
 public class ErrorResponse {

--- a/src/main/java/com/sds/actlongs/model/ResultCode.java
+++ b/src/main/java/com/sds/actlongs/model/ResultCode.java
@@ -1,0 +1,16 @@
+package com.sds.actlongs.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+
+	// Member
+	LOGIN_SUCCESS(200, "M001", "로그인에 성공하였습니다.");
+
+	private final int status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sds/actlongs/model/ResultResponse.java
+++ b/src/main/java/com/sds/actlongs/model/ResultResponse.java
@@ -1,0 +1,20 @@
+package com.sds.actlongs.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public abstract class ResultResponse {
+
+	private int status;
+	private String code;
+	private String message;
+
+	public ResultResponse(ResultCode resultCode) {
+		this.status = resultCode.getStatus();
+		this.code = resultCode.getCode();
+		this.message = resultCode.getMessage();
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/model/ResultResponse.java
+++ b/src/main/java/com/sds/actlongs/model/ResultResponse.java
@@ -1,14 +1,20 @@
 package com.sds.actlongs.model;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@ApiModel(description = "응답 결과 공통 모델(정상)")
 @Data
 @NoArgsConstructor
 public abstract class ResultResponse {
 
+	@ApiModelProperty(value = "HTTP 상태 코드", example = "200")
 	private int status;
+	@ApiModelProperty(value = "Business 상태 코드", example = "M001")
 	private String code;
+	@ApiModelProperty(value = "결과 메세지", example = "로그인에 성공하였습니다.")
 	private String message;
 
 	public ResultResponse(ResultCode resultCode) {

--- a/src/main/java/com/sds/actlongs/util/Constants.java
+++ b/src/main/java/com/sds/actlongs/util/Constants.java
@@ -1,0 +1,12 @@
+package com.sds.actlongs.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class Constants {
+
+	public static final String EMPTY = "";
+	public static final String DOT = ".";
+
+}


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-1

### 개요
API 호출 결과 응답 데이터를 통일하고, 예외 처리를 담당하는 핸들러를 구현하자.

---

### 변경사항
- 모든 API 응답 모델들은 ResultResponse을 상속해서 사용해요.
```java
@Data
@NoArgsConstructor
public class RegisterMemberResponse extends ResultResponse {

    private String username;

    public ResultResponse(String username) {
        super(ResultCode.LOGIN_SUCCESS);
        this.username = username;
    }

}
```
- 비즈니스 상에서 발생하는 예외를 커스터마이징하는 경우, BusinessException을 상속해서 사용해요.
- BusinessException은 비즈니스 상에서 발생하는 예외들을 가리키는 추상 클래스에요.
- 하나의 ExceptionHandler로 모든 비즈니스 예외를 처리하기 위한 목적으로 만들었어요.
```java
public class EntityAlreadyExistException extends BusinessException {

	public EntityAlreadyExistException(ErrorCode errorCode) {
		super(errorCode);
	}

}
```

- ResultCode와 ErrorCode는 merge conflict가 자주 발생할 수 있는 부분이에요. 이 점 주의해서 작업해주세요.

-  여러 가지 예외들을 AOP(RestControllerAdvice)를 이용하여 한 곳(GlobalExceptionHandler)에서 처리해요.

---

### 리뷰 받고 싶은 내용
공통으로 쓰이는 부분을 작업한 거라, 팀원 모두의 합의가 필요해요.
이해가 안되는 코드가 있거나, 다른 제안 사항이 있다면 자유롭게 알려주세요.