### PR TITLE
[SL-101] Group Entity 추가

### DIFF
--- a/src/main/java/com/sds/actlongs/domain/group/entity/Group.java
+++ b/src/main/java/com/sds/actlongs/domain/group/entity/Group.java
@@ -1,0 +1,51 @@
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.sds.actlongs.domain.BaseEntity;
+import com.sds.actlongs.domain.member.entity.Member;
+import com.sds.actlongs.vo.ImageExtension;
+
+@Entity(name = "groups")
+@Getter
+@NoArgsConstructor
+public class Group extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "owner_id")
+	private Member owner;
+
+	@Column(nullable = false, unique = true, length = 20)
+	private String name;
+
+	@Column(unique = true, length = 36)
+	private String groupImageUuid;
+
+	@Enumerated(EnumType.STRING)
+	private ImageExtension groupImageType;
+
+	public Group(String name, Member owner, String groupImageUuid, ImageExtension groupImageType) {
+		this.name = name;
+		this.owner = owner;
+		this.groupImageUuid = groupImageUuid;
+		this.groupImageType = groupImageType;
+	}
+
+	public static Group createNewGroup(String name, Member owner) {
+		return new Group(name, owner, null, null);
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/sds/actlongs/domain/group/repository/GroupRepository.java
@@ -1,0 +1,9 @@
+package com.sds.actlongs.domain.group.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sds.actlongs.domain.group.entity.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+}

--- a/src/test/java/com/sds/actlongs/domain/group/repository/GroupRepositoryTest.java
+++ b/src/test/java/com/sds/actlongs/domain/group/repository/GroupRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.sds.actlongs.domain.group.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.sds.actlongs.config.JpaAuditingConfig;
+import com.sds.actlongs.domain.group.entity.Group;
+import com.sds.actlongs.domain.member.entity.Member;
+
+@Import(JpaAuditingConfig.class)
+@DataJpaTest
+class GroupRepositoryTest {
+
+	@Autowired
+	private GroupRepository subject;
+
+	@Nested
+	class Save {
+
+		@Test
+		@DisplayName("새로운 그룹을 생성하면, DB에서 ID를 자동적으로 부여한다.")
+		void ifCreateGroupThenIdIsAutomaticallyGiven() {
+			// given
+			Member member = Member.createNewMember("Harry");
+			Group group = Group.createNewGroup("Knox SRE", member);
+
+			// when
+			Group result = subject.save(group);
+
+			// then
+			Assertions.assertThat(result.getId()).isNotNull();
+			Assertions.assertThat(result.getOwner().getUsername()).isEqualTo("Harry");
+		}
+
+	}
+
+}


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-0

### 개요

Group Entity 추가
* groups 테이블은 owner_id 를 외래키로 갖는다.

---

### 변경사항

* Group Entity를 구성하고 owner_id 참조를 위해 Member와 Join 관계를 설정함.
* Harry 라는 멤버가 그룹을 생성했을 때 owner가 Harry로 잘 저장되는지 테스트하는 코드를 작성함.

---

### 리뷰 받고 싶은 내용
