### PR TITLE
[SL-128] 로그인 API 구현 (Session 사용)

### DIFF
--- a/src/main/java/com/sds/actlongs/controller/member/MemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/member/MemberController.java
@@ -1,0 +1,43 @@
+package com.sds.actlongs.controller.member;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sds.actlongs.controller.member.dto.LoginRequest;
+import com.sds.actlongs.controller.member.dto.LoginResponse;
+import com.sds.actlongs.domain.member.entity.Member;
+import com.sds.actlongs.service.member.MemberService;
+import com.sds.actlongs.util.SessionConstants;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponse> login(@RequestBody final LoginRequest dto, HttpServletRequest request) {
+
+		Member member = memberService.login(dto.getUsername());
+		if (member == null) {
+			return ResponseEntity.ok().body(LoginResponse.fail());
+		}
+
+		HttpSession session = request.getSession();
+		session.setAttribute(SessionConstants.MEMBER_ID, member.getId());
+		return ResponseEntity.ok().body(LoginResponse.succeed());
+
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/controller/member/dto/LoginRequest.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/LoginRequest.java
@@ -1,0 +1,2 @@
+package com.sds.actlongs.controller.member.dto;public class LoginRequest {
+}

--- a/src/main/java/com/sds/actlongs/controller/member/dto/LoginResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/LoginResponse.java
@@ -1,0 +1,2 @@
+package com.sds.actlongs.controller.member.dto;public class LoginResponse {
+}

--- a/src/main/java/com/sds/actlongs/service/member/MemberService.java
+++ b/src/main/java/com/sds/actlongs/service/member/MemberService.java
@@ -1,0 +1,7 @@
+package com.sds.actlongs.service.member;
+
+import com.sds.actlongs.domain.member.entity.Member;
+
+public interface MemberService {
+	Member login(final String username);
+}

--- a/src/main/java/com/sds/actlongs/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/member/MemberServiceImpl.java
@@ -1,0 +1,21 @@
+package com.sds.actlongs.service.member;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.sds.actlongs.domain.member.entity.Member;
+import com.sds.actlongs.domain.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public Member login(final String username) {
+		return memberRepository.findByUsername(username);
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/util/SessionConstants.java
+++ b/src/main/java/com/sds/actlongs/util/SessionConstants.java
@@ -1,0 +1,11 @@
+package com.sds.actlongs.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SessionConstants {
+
+	public static final String MEMBER_ID = "memberId";
+
+}

--- a/src/test/java/com/sds/actlongs/service/member/MemberServiceImplTest.java
+++ b/src/test/java/com/sds/actlongs/service/member/MemberServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.sds.actlongs.service.member;
+
+import static org.mockito.BDDMockito.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sds.actlongs.domain.member.entity.Member;
+import com.sds.actlongs.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceImplTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private MemberServiceImpl subject;
+
+	@Nested
+	class Login {
+
+		@Test
+		@DisplayName("존재하는 사용자 아이디로 로그인하면, 로그인에 성공한다.")
+		void ifLoginWithExistingUsernameThenSucceed() {
+			//given
+			String username = "Harry";
+			Member member = Member.createNewMember(username);
+			given(memberRepository.findByUsername(username)).willReturn(member);
+
+			//when
+			Member result = subject.login(username);
+
+			//then
+			Assertions.assertThat(result.getUsername()).isEqualTo(username);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 사용자 아이디로 로그인하면, 로그인에 실패한다.")
+		void ifLoginWithNotExistingUsernameThenFail() {
+			//given
+			String username = "Harry";
+			given(memberRepository.findByUsername(username)).willReturn(null);
+
+			//when
+			Member result = subject.login(username);
+
+			//then
+			Assertions.assertThat(result).isNull();
+		}
+
+	}
+
+}


### PR DESCRIPTION
### 리뷰 요청
- [ ] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-0

### 개요

로그인 API 구현

---

### 변경사항

* 세션을 활용하여 MemberController와 MemberService 추가
* MemberServiceImpl 테스트 코드 작성
  * 존재하는 사용자 아이디로 로그인하면, 로그인에 성공한다.
  * 존재하지 않는 사용자 아이디로 로그인하면, 로그인에 실패한다.

---

### 리뷰 받고 싶은 내용
