### PR TITLE
Bean Validation 오동작 이슈 해결 및 Swagger docs 업데이트

### DIFF
--- a/src/main/java/com/sds/actlongs/controller/member/MemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/member/MemberController.java
@@ -1,9 +1,9 @@
 package com.sds.actlongs.controller.member;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +18,6 @@ import com.sds.actlongs.controller.member.dto.LoginResponse;
 import com.sds.actlongs.service.member.MemberService;
 
 @Api(tags = "회원 API")
-@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
@@ -28,8 +27,9 @@ public class MemberController {
 
 	@ApiOperation(value = "로그인 API")
 	@PostMapping("/login")
-	public ResponseEntity<LoginResponse> login(@RequestBody final LoginRequest dto, final HttpServletRequest request) {
-		final boolean result = memberService.login(dto.getUsername(), request.getSession());
+	public ResponseEntity<LoginResponse> login(@Valid @RequestBody final LoginRequest request,
+		final HttpServletRequest servletRequest) {
+		final boolean result = memberService.login(request.getUsername(), servletRequest.getSession());
 		return ResponseEntity.ok(LoginResponse.of(result));
 	}
 

--- a/src/main/java/com/sds/actlongs/controller/member/MemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/member/MemberController.java
@@ -25,7 +25,9 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@ApiOperation(value = "로그인 API")
+	@ApiOperation(value = "로그인 API", notes = ""
+		+ "M001: 로그인에 성공하였습니다.\n"
+		+ "M002: 로그인에 실패하였습니다.")
 	@PostMapping("/login")
 	public ResponseEntity<LoginResponse> login(@Valid @RequestBody final LoginRequest request,
 		final HttpServletRequest servletRequest) {

--- a/src/main/java/com/sds/actlongs/controller/member/dto/LoginRequest.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/LoginRequest.java
@@ -15,7 +15,7 @@ public class LoginRequest {
 
 	@NotBlank
 	@Size(max = 20)
-	@ApiModelProperty(value = "아이디", example = "harry", required = true)
+	@ApiModelProperty(value = "아이디(최대 20자, 공백 불가)", example = "harry", required = true)
 	private String username;
 
 }


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-x

### 개요
- 클래스 수준에 `@Validated`만 적용되어 있어 Bean Validation이 동작하지 않는 이슈를 해결해요.
- Swagger docs에 필요한 정보를 추가해요.

---

### 변경사항
### 1. 클래스 수준에서 `@Validated`를 제거하고, 메소드 수준에 `@Valid`를 추가하기
#### `@Valid` vs `@Validated`
- `@Valid`
    - JSR-303 자바 표준 스펙
    - 특정 ArgumentResolver를 통해 진행되어 컨트롤러 메소드의 유효성 검증만 가능하다.
    - 유효성 검증에 실패할 경우 MethodArgumentNotValidException이 발생한다.
- `@Validated`
    - 자바 표준 스펙이 아닌 스프링 프레임워크가 제공하는 기능
    - AOP를 기반으로 스프링 빈의 유효성 검증을 위해 사용되며 클래스에는 `@Validated`를, 메소드에는 `@Valid`를 붙여주어야 한다.
    - 유효성 검증에 실패할 경우 ConstraintViolationException이 발생한다.
    - 유효성 검증 그룹 지정(groups)이 가능하나, 코드가 복잡해져서 거의 사용되지 않는다.

Controller 계층에서는 `@Valid` 사용으로 통일하면 어떨까 해요.
- 이 외 계층에서는 `@Valid`를 이용한 Bean Validation이 불가능하므로, `@Validated`를 활용하는 식으로 구분하면 좋을 것 같아요.
- Controller 계층에서도 동일하게 `@Validated`를 붙여주어도 상관 없지만, 꼭 필요한 방법이 아니므로 어노테이션 하나 추가하는 귀찮음은 덜어버리기로..
> `@Validated` 사용하면 메소드 수준에 `@Valid`도 같이 추가해줘야 했는데, 잘못된 정보를 공유드려서 죄송해요 @nureesong 


### 2. Swagger docs 정보 업데이트하기
- 요청 데이터 모델에서 각 필드마다 어떤 검증을 수행하는지 정보를 추가했어요.
- API description에 결과로 발생할 수 있는 비즈니스 코드 정보를 추가했어요.
    - HTTP status code가 4xx, 5xx 인 정보는 추가하지 않아요.
> Swagger docs 작성법에 대해서는 6.15(목)에 간단하게 구두로 설명 해드릴게요.

---

### 리뷰 받고 싶은 내용
