### PR TITLE
[SL-157] 메소드 실행 시간 측정 AOP 구현

### DIFF
--- a/src/main/java/com/sds/actlongs/advice/ExecutionTimeAspect.java
+++ b/src/main/java/com/sds/actlongs/advice/ExecutionTimeAspect.java
@@ -1,0 +1,31 @@
+package com.sds.actlongs.advice;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.sds.actlongs.util.TimeUtils;
+
+@Slf4j
+@Aspect
+@Component
+public class ExecutionTimeAspect {
+
+	@Around("@annotation(com.sds.actlongs.annotation.MeasureExecutionTime)")
+	public Object measureExecutionTime(final ProceedingJoinPoint joinPoint) throws Throwable {
+		log.debug("Start to measure execution time of {}", joinPoint.toString());
+		final long start = System.currentTimeMillis();
+		try {
+			return joinPoint.proceed();
+		} finally {
+			final long finish = System.currentTimeMillis();
+			final long timeMilliseconds = finish - start;
+			log.debug("Execution time of {}: {}", joinPoint.getSignature(),
+				TimeUtils.formatMilliseconds(timeMilliseconds));
+		}
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/annotation/MeasureExecutionTime.java
+++ b/src/main/java/com/sds/actlongs/annotation/MeasureExecutionTime.java
@@ -1,0 +1,12 @@
+package com.sds.actlongs.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface MeasureExecutionTime {
+
+}

--- a/src/main/java/com/sds/actlongs/util/Constants.java
+++ b/src/main/java/com/sds/actlongs/util/Constants.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public final class Constants {
 
 	public static final String EMPTY = "";
+	public static final String SPACE = " ";
 	public static final String DOT = ".";
 	public static final String WILDCARD = "*";
 	public static final String ALL_PATH = "/**";

--- a/src/main/java/com/sds/actlongs/util/TimeUtils.java
+++ b/src/main/java/com/sds/actlongs/util/TimeUtils.java
@@ -15,7 +15,7 @@ public class TimeUtils {
 	private static final int MINUTE = SECOND * SECONDS_PER_MINUTE;
 	private static final int HOUR = MINUTE * SECONDS_PER_MINUTE;
 
-	public static String formatMilliseconds(long milliseconds) {
+	public static String formatMilliseconds(final long milliseconds) {
 		if (milliseconds < SECOND) {
 			return milliseconds + MILLISECONDS_UNIT;
 		} else if (milliseconds < MINUTE) {

--- a/src/main/java/com/sds/actlongs/util/TimeUtils.java
+++ b/src/main/java/com/sds/actlongs/util/TimeUtils.java
@@ -1,0 +1,41 @@
+package com.sds.actlongs.util;
+
+import static com.sds.actlongs.util.Constants.*;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeUtils {
+
+	private static final String MILLISECONDS_UNIT = "ms";
+	private static final String SECONDS_UNIT = "s";
+	private static final String MINUTES_UNIT = "m";
+	private static final String HOURS_UNIT = "h";
+	private static final int SECOND = 1000;
+	private static final int SECONDS_PER_MINUTE = 60;
+	private static final int MINUTE = SECOND * SECONDS_PER_MINUTE;
+	private static final int HOUR = MINUTE * SECONDS_PER_MINUTE;
+
+	public static String formatMilliseconds(long milliseconds) {
+		if (milliseconds < SECOND) {
+			return milliseconds + MILLISECONDS_UNIT;
+		} else if (milliseconds < MINUTE) {
+			final long seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds);
+			final long remainingMilliseconds = milliseconds % SECOND;
+			return seconds + SECONDS_UNIT + SPACE + remainingMilliseconds + MILLISECONDS_UNIT;
+		} else if (milliseconds < HOUR) {
+			final long minutes = TimeUnit.MILLISECONDS.toMinutes(milliseconds);
+			final long remainingSeconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds) % SECONDS_PER_MINUTE;
+			final long remainingMilliseconds = milliseconds % SECOND;
+			return minutes + MINUTES_UNIT + SPACE + remainingSeconds + SECONDS_UNIT + SPACE + remainingMilliseconds
+				+ MILLISECONDS_UNIT;
+		} else {
+			final long hours = TimeUnit.MILLISECONDS.toHours(milliseconds);
+			final long remainingMinutes = TimeUnit.MILLISECONDS.toMinutes(milliseconds) % SECONDS_PER_MINUTE;
+			final long remainingSeconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds) % SECONDS_PER_MINUTE;
+			final long remainingMilliseconds = milliseconds % SECOND;
+			return hours + HOURS_UNIT + SPACE + remainingMinutes + MINUTES_UNIT + SPACE + remainingSeconds
+				+ SECONDS_UNIT + SPACE + remainingMilliseconds + MILLISECONDS_UNIT;
+		}
+	}
+
+}

--- a/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
+++ b/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.*;
 import java.util.List;
 
 import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,9 +37,6 @@ class ExecutionTimeAspectTest {
 		@DisplayName("메소드의 실행 시간을 Debug level log로 출력한다.")
 		void measureExecutionTime() throws Throwable {
 			// given
-			final MethodSignature methodSignature = mock(MethodSignature.class);
-			given(joinPoint.getSignature()).willReturn(methodSignature);
-
 			final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
 			listAppender.start();
 			logger.addAppender(listAppender);

--- a/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
+++ b/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
@@ -1,0 +1,64 @@
+package com.sds.actlongs.advice;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutionTimeAspectTest {
+
+	@Mock
+	private ProceedingJoinPoint joinPoint;
+
+	private Logger logger = (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(
+		"com.sds.actlongs.advice.ExecutionTimeAspect");
+
+	@InjectMocks
+	private ExecutionTimeAspect subject;
+
+	@Nested
+	class MeasureExecutionTime {
+
+		@Test
+		@DisplayName("메소드의 실행 시간을 Debug level log로 출력한다.")
+		void measureExecutionTime() throws Throwable {
+			// given
+			final MethodSignature methodSignature = mock(MethodSignature.class);
+			final String mockMethodSignature = "mockMethod";
+			given(methodSignature.toString()).willReturn(mockMethodSignature);
+			given(joinPoint.getSignature()).willReturn(methodSignature);
+
+			final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+			listAppender.start();
+			logger.addAppender(listAppender);
+			final List<ILoggingEvent> loggingEvents = listAppender.list;
+
+			// when
+			subject.measureExecutionTime(joinPoint);
+
+			// then
+			then(joinPoint).should(times(1)).proceed();
+			assertThat("DEBUG").isEqualTo(loggingEvents.get(0).getLevel().toString());
+			assertThat("Start to measure execution time of {}").isEqualTo(loggingEvents.get(0).getMessage());
+			assertThat("Execution time of {}: {}").isEqualTo(loggingEvents.get(1).getMessage());
+		}
+
+	}
+
+}

--- a/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
+++ b/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
@@ -26,8 +26,7 @@ class ExecutionTimeAspectTest {
 	@Mock
 	private ProceedingJoinPoint joinPoint;
 
-	private Logger logger = (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(
-		"com.sds.actlongs.advice.ExecutionTimeAspect");
+	private Logger logger = (Logger)LoggerFactory.getLogger(ExecutionTimeAspect.class);
 
 	@InjectMocks
 	private ExecutionTimeAspect subject;

--- a/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
+++ b/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
@@ -54,6 +54,7 @@ class ExecutionTimeAspectTest {
 			// then
 			then(joinPoint).should(times(1)).proceed();
 			assertThat("DEBUG").isEqualTo(loggingEvents.get(0).getLevel().toString());
+			assertThat("DEBUG").isEqualTo(loggingEvents.get(1).getLevel().toString());
 			assertThat("Start to measure execution time of {}").isEqualTo(loggingEvents.get(0).getMessage());
 			assertThat("Execution time of {}: {}").isEqualTo(loggingEvents.get(1).getMessage());
 		}

--- a/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
+++ b/src/test/java/com/sds/actlongs/advice/ExecutionTimeAspectTest.java
@@ -39,8 +39,6 @@ class ExecutionTimeAspectTest {
 		void measureExecutionTime() throws Throwable {
 			// given
 			final MethodSignature methodSignature = mock(MethodSignature.class);
-			final String mockMethodSignature = "mockMethod";
-			given(methodSignature.toString()).willReturn(mockMethodSignature);
 			given(joinPoint.getSignature()).willReturn(methodSignature);
 
 			final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();

--- a/src/test/java/com/sds/actlongs/util/TimeUtilsTest.java
+++ b/src/test/java/com/sds/actlongs/util/TimeUtilsTest.java
@@ -1,0 +1,67 @@
+package com.sds.actlongs.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TimeUtilsTest {
+
+	@Nested
+	class FormatMilliseconds {
+
+		@Test
+		void ifLessThanSecondThenReturnMillisecondsUnit() {
+			// given
+			final long milliseconds = 999;
+			final String expected = "999ms";
+
+			// when
+			final String result = TimeUtils.formatMilliseconds(milliseconds);
+
+			// then
+			assertThat(result).isEqualTo(expected);
+		}
+
+		@Test
+		void ifLessThanMinuteThenReturnSecondsUnit() {
+			// given
+			final long milliseconds = 999 * 60;
+			final String expected = "59s 940ms";
+
+			// when
+			final String result = TimeUtils.formatMilliseconds(milliseconds);
+
+			// then
+			assertThat(result).isEqualTo(expected);
+		}
+
+		@Test
+		void ifLessThanHourThenReturnMinutesUnit() {
+			// given
+			final long milliseconds = 999 * 60 * 60;
+			final String expected = "59m 56s 400ms";
+
+			// when
+			final String result = TimeUtils.formatMilliseconds(milliseconds);
+
+			// then
+			assertThat(result).isEqualTo(expected);
+		}
+
+		@Test
+		void ifMoreThanHourThenReturnHoursUnit() {
+			// given
+			final long milliseconds = 1000 * 60 * 60 + 1;
+			final String expected = "1h 0m 0s 1ms";
+
+			// when
+			final String result = TimeUtils.formatMilliseconds(milliseconds);
+
+			// then
+			assertThat(result).isEqualTo(expected);
+		}
+
+	}
+
+}


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-1

### 개요
- 메소드 실행 시간을 측정하는 AOP 기능을 구현해요.

---

### 변경사항
- 테스트하고 싶은 public method에 `@ExecutionTimeAspect`을 추가하면 debug level log로 실행 시간을 확인할 수 있어요.
- 유틸 기능도 추가했어요. `TimeUtils`
    - miliseconds가 주어지면, 시간, 분, 초, 밀리초 단위로 이쁘게 formatting한 문자열을 반환해주는 메소드를 추가했어요.

---

### 리뷰 받고 싶은 내용
@hongsam123`(AOP 전문가)` 리뷰리뷰 ( ͡° ͜ʖ ͡°) 👀