### PR TITLE
[SL-175] 인증 filter 구현

### DIFF
--- a/src/main/java/com/sds/actlongs/config/SwaggerConfig.java
+++ b/src/main/java/com/sds/actlongs/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -26,7 +27,8 @@ public class SwaggerConfig {
 			.select()
 			.apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
 			.paths(PathSelectors.any())
-			.build();
+			.build()
+			.ignoredParameterTypes(SessionAttribute.class);
 	}
 
 	private ApiInfo apiInfo() {

--- a/src/main/java/com/sds/actlongs/config/WebConfig.java
+++ b/src/main/java/com/sds/actlongs/config/WebConfig.java
@@ -2,31 +2,44 @@ package com.sds.actlongs.config;
 
 import static com.sds.actlongs.util.Constants.*;
 
+import javax.servlet.Filter;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.reactive.CorsUtils;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.sds.actlongs.filter.AuthenticationFilter;
 
 @Configuration
 public class WebConfig {
 
 	@Bean
 	@Profile({"local", "dev"})
-	public WebMvcConfigurer localCorsConfigurer() {
+	public WebMvcConfigurer localAndDevCorsConfigurer() {
 		return new WebMvcConfigurer() {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry
-					.addMapping(ALL_PATH)
+					.addMapping(ALL_SUB_PATHS)
 					.allowedMethods(CorsConfiguration.ALL)
 					.allowedOrigins("http://localhost:3000")
 					.allowedHeaders(CorsConfiguration.ALL)
 					.allowCredentials(true);
 			}
 		};
+	}
+
+	@Bean
+	public FilterRegistrationBean<Filter> AuthenticationFilter(){
+		final FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+		filterRegistrationBean.setFilter(new AuthenticationFilter());
+		filterRegistrationBean.setOrder(2);
+		filterRegistrationBean.addUrlPatterns(ALL_PATHS);
+		return filterRegistrationBean;
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/config/WebConfig.java
+++ b/src/main/java/com/sds/actlongs/config/WebConfig.java
@@ -34,7 +34,7 @@ public class WebConfig {
 	}
 
 	@Bean
-	public FilterRegistrationBean<Filter> AuthenticationFilter(){
+	public FilterRegistrationBean<Filter> authenticationFilter() {
 		final FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
 		filterRegistrationBean.setFilter(new AuthenticationFilter());
 		filterRegistrationBean.setOrder(1);

--- a/src/main/java/com/sds/actlongs/config/WebConfig.java
+++ b/src/main/java/com/sds/actlongs/config/WebConfig.java
@@ -37,7 +37,7 @@ public class WebConfig {
 	public FilterRegistrationBean<Filter> AuthenticationFilter(){
 		final FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
 		filterRegistrationBean.setFilter(new AuthenticationFilter());
-		filterRegistrationBean.setOrder(2);
+		filterRegistrationBean.setOrder(1);
 		filterRegistrationBean.addUrlPatterns(ALL_PATHS);
 		return filterRegistrationBean;
 	}

--- a/src/main/java/com/sds/actlongs/controller/member/MemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/member/MemberController.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.member;
 
+import static com.sds.actlongs.util.SessionConstants.*;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -40,7 +43,7 @@ public class MemberController {
 	@ApiOperation(value = "회원정보 조회 API", notes = ""
 		+ "MI001: 회원정보 조회에 성공하였습니다.")
 	@GetMapping("/info")
-	public ResponseEntity<MemberInfoResponse> memberInfo() {
+	public ResponseEntity<MemberInfoResponse> memberInfo(@SessionAttribute(MEMBER_ID) Long memberId) {
 		return ResponseEntity.ok(MemberInfoResponse.of(1L, "Harry"));
 	}
 

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -63,6 +63,7 @@ public class AuthenticationFilter implements Filter {
 			os.flush();
 		} catch (Exception exception) {
 			exception.printStackTrace();
+			throw new RuntimeException(exception.getMessage(), exception.getCause());
 		}
 	}
 

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -42,11 +42,10 @@ public class AuthenticationFilter implements Filter {
 
 	private boolean processAuthenticationAndGetResult(HttpServletRequest httpRequest,
 		HttpServletResponse httpResponse) {
-		if (isAuthenticationPath(httpRequest.getRequestURI())) {
-			if (isSessionExpiredOrInvalid(httpRequest.getSession(false))) {
-				handleAuthenticationFailure(httpResponse);
-				return false;
-			}
+		if (isAuthenticationPath(httpRequest.getRequestURI()) &&
+			isSessionExpiredOrInvalid(httpRequest.getSession(false))) {
+			handleAuthenticationFailure(httpResponse);
+			return false;
 		}
 		return true;
 	}

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -28,18 +28,14 @@ public class AuthenticationFilter implements Filter {
 
 	private static final String[] API_WHITELIST = {"/members/login"};
 	private static final String[] SWAGGER_WHITELIST = {"/v2/api-docs/**", "/configuration/ui/**",
-		"/swagger-resources/**",
-		"/configuration/security/**", "/swagger-ui.html/**", "/webjars/**", "/swagger/**"};
+		"/swagger-resources/**", "/configuration/security/**", "/swagger-ui.html/**", "/webjars/**", "/swagger/**"};
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 		throws ServletException, IOException {
-		final HttpServletRequest httpRequest = (HttpServletRequest)request;
-		final HttpServletResponse httpResponse = (HttpServletResponse)response;
-
-		if (processAuthenticationAndGetResult(httpRequest, httpResponse)) {
+		if (processAuthenticationAndGetResult((HttpServletRequest)request, (HttpServletResponse)response)) {
 			chain.doFilter(request, response);
 		}
 	}

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -42,8 +42,8 @@ public class AuthenticationFilter implements Filter {
 
 	private boolean processAuthenticationAndGetResult(HttpServletRequest httpRequest,
 		HttpServletResponse httpResponse) {
-		if (isAuthenticationPath(httpRequest.getRequestURI()) &&
-			isSessionExpiredOrInvalid(httpRequest.getSession(false))) {
+		if (isAuthenticationPath(httpRequest.getRequestURI())
+			&& isSessionExpiredOrInvalid(httpRequest.getSession(false))) {
 			handleAuthenticationFailure(httpResponse);
 			return false;
 		}

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -20,16 +20,15 @@ import org.springframework.http.MediaType;
 import org.springframework.util.AntPathMatcher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
 
 import com.sds.actlongs.model.ErrorResponse;
 import com.sds.actlongs.util.SessionConstants;
 
-@Slf4j
 public class AuthenticationFilter implements Filter {
 
 	private static final String[] API_WHITELIST = {"/members/login"};
-	private static final String[] SWAGGER_WHITELIST = {"/v2/api-docs/**", "/configuration/ui/**", "/swagger-resources/**",
+	private static final String[] SWAGGER_WHITELIST = {"/v2/api-docs/**", "/configuration/ui/**",
+		"/swagger-resources/**",
 		"/configuration/security/**", "/swagger-ui.html/**", "/webjars/**", "/swagger/**"};
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final AntPathMatcher antPathMatcher = new AntPathMatcher();

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -67,8 +67,8 @@ public class AuthenticationFilter implements Filter {
 		}
 	}
 
-	private boolean isAuthenticationPath(String requestURI) {
-		return getWhitelistStream().noneMatch(uri -> antPathMatcher.match(uri, requestURI));
+	private boolean isAuthenticationPath(String requestUri) {
+		return getWhitelistStream().noneMatch(uri -> antPathMatcher.match(uri, requestUri));
 	}
 
 	private Stream<String> getWhitelistStream() {

--- a/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
+++ b/src/main/java/com/sds/actlongs/filter/AuthenticationFilter.java
@@ -1,0 +1,84 @@
+package com.sds.actlongs.filter;
+
+import static com.sds.actlongs.model.ErrorCode.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.http.MediaType;
+import org.springframework.util.AntPathMatcher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import com.sds.actlongs.model.ErrorResponse;
+import com.sds.actlongs.util.SessionConstants;
+
+@Slf4j
+public class AuthenticationFilter implements Filter {
+
+	private static final String[] API_WHITELIST = {"/members/login"};
+	private static final String[] SWAGGER_WHITELIST = {"/v2/api-docs/**", "/configuration/ui/**", "/swagger-resources/**",
+		"/configuration/security/**", "/swagger-ui.html/**", "/webjars/**", "/swagger/**"};
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws ServletException, IOException {
+		final HttpServletRequest httpRequest = (HttpServletRequest)request;
+		final HttpServletResponse httpResponse = (HttpServletResponse)response;
+
+		if (processAuthenticationAndGetResult(httpRequest, httpResponse)) {
+			chain.doFilter(request, response);
+		}
+	}
+
+	private boolean processAuthenticationAndGetResult(HttpServletRequest httpRequest,
+		HttpServletResponse httpResponse) {
+		if (isAuthenticationPath(httpRequest.getRequestURI())) {
+			if (isSessionExpiredOrInvalid(httpRequest.getSession(false))) {
+				handleAuthenticationFailure(httpResponse);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean isSessionExpiredOrInvalid(HttpSession session) {
+		return session == null || session.getAttribute(SessionConstants.MEMBER_ID) == null;
+	}
+
+	private void handleAuthenticationFailure(HttpServletResponse httpResponse) {
+		httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		httpResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		try (OutputStream os = httpResponse.getOutputStream()) {
+			objectMapper.writeValue(os, ErrorResponse.of(AUTHENTICATION_FAILURE));
+			os.flush();
+		} catch (Exception exception) {
+			exception.printStackTrace();
+		}
+	}
+
+	private boolean isAuthenticationPath(String requestURI) {
+		return getWhitelistStream().noneMatch(uri -> antPathMatcher.match(uri, requestURI));
+	}
+
+	private Stream<String> getWhitelistStream() {
+		return Stream.concat(
+			Arrays.stream(API_WHITELIST),
+			Arrays.stream(SWAGGER_WHITELIST));
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/model/ErrorCode.java
+++ b/src/main/java/com/sds/actlongs/model/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	REQUEST_PARAMETER_MISSING(400, "E-G006", "요청 파라미터는 필수입니다."),
 	REQUEST_HEADER_MISSING(400, "E-G007", "요청 헤더는 필수입니다."),
 	ENTITY_NOT_FOUND(404, "E-G008", "존재하지 않는 Entity 입니다."),
+	AUTHENTICATION_FAILURE(401, "E-G009", "인증에 실패하였습니다."),
 
 	// Member
 	MEMBERINFO_FAILURE(500, "E-M001", "회원정보 조회에 실패하였습니다.");

--- a/src/main/java/com/sds/actlongs/util/Constants.java
+++ b/src/main/java/com/sds/actlongs/util/Constants.java
@@ -11,7 +11,8 @@ public final class Constants {
 	public static final String HYPHEN = "-";
 	public static final String DOT = ".";
 	public static final String WILDCARD = "*";
-	public static final String ALL_PATH = "/**";
+	public static final String ALL_SUB_PATHS = "/**";
+	public static final String ALL_PATHS = "/*";
 	public static final String CATEGORY_PREFIX = "/";
 
 }

--- a/src/test/java/com/sds/actlongs/filter/AuthenticationFilterTest.java
+++ b/src/test/java/com/sds/actlongs/filter/AuthenticationFilterTest.java
@@ -20,8 +20,8 @@ import com.sds.actlongs.util.SessionConstants;
 @ExtendWith(MockitoExtension.class)
 class AuthenticationFilterTest {
 
-	private final static String AUTHENTICATION_PATH = "/members/info";
-	private final static String AUTHENTICATION_WHITELIST_PATH = "/members/login";
+	private static final String AUTHENTICATION_PATH = "/members/info";
+	private static final String AUTHENTICATION_WHITELIST_PATH = "/members/login";
 	@InjectMocks
 	private AuthenticationFilter subject;
 	@Mock

--- a/src/test/java/com/sds/actlongs/filter/AuthenticationFilterTest.java
+++ b/src/test/java/com/sds/actlongs/filter/AuthenticationFilterTest.java
@@ -1,0 +1,84 @@
+package com.sds.actlongs.filter;
+
+import static org.mockito.BDDMockito.*;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sds.actlongs.util.SessionConstants;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationFilterTest {
+
+	private final static String AUTHENTICATION_PATH = "/members/info";
+	private final static String AUTHENTICATION_WHITELIST_PATH = "/members/login";
+	@InjectMocks
+	private AuthenticationFilter subject;
+	@Mock
+	private HttpServletRequest request;
+	@Mock
+	private HttpServletResponse response;
+	@Mock
+	private FilterChain filterChain;
+	@Mock
+	private HttpSession session;
+	@Mock
+	private ServletOutputStream outputStream;
+
+	@Nested
+	class DoFilter {
+
+		@Test
+		void ifAuthenticationPathAndSessionValidThenCallFilterChainDoFilter() throws Exception {
+			// given
+			given(request.getRequestURI()).willReturn(AUTHENTICATION_PATH);
+
+			final Long memberId = 1L;
+			given(request.getSession(false)).willReturn(session);
+			given(session.getAttribute(SessionConstants.MEMBER_ID)).willReturn(memberId);
+
+			// when
+			subject.doFilter(request, response, filterChain);
+
+			// then
+			then(filterChain).should(times(1)).doFilter(request, response);
+		}
+
+		@Test
+		void ifAuthenticationPathAndSessionInvalidThenDoNotCallFilterChainDoFilter() throws Exception {
+			// given
+			given(request.getRequestURI()).willReturn(AUTHENTICATION_PATH);
+			given(response.getOutputStream()).willReturn(outputStream);
+
+			// when
+			subject.doFilter(request, response, filterChain);
+
+			// then
+			then(filterChain).should(never()).doFilter(request, response);
+		}
+
+		@Test
+		void ifAuthenticationWhitelistPathAndSessionValidThenCallFilterChainDoFilter() throws Exception {
+			// given
+			given(request.getRequestURI()).willReturn(AUTHENTICATION_WHITELIST_PATH);
+
+			// when
+			subject.doFilter(request, response, filterChain);
+
+			// then
+			then(filterChain).should(times(1)).doFilter(request, response);
+		}
+
+	}
+
+}


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-1

### 개요
모든 HTTP 요청에 대해 공통적으로 인증 처리를 하는 기능을 추가해요.

---

### 변경사항
- 인증 필터(`AuthenticationFilter`)를 추가했어요.
    - 멤버 변수로 인증 필터를 거치지 않을 Whitelist를 관리해요.
    - 인증에 성공할 경우, 다음 filter가 동작해요.
    - 인증에 실패할 경우, 인증 실패에 대한 HTTP 응답을 구성하고, 종료돼요. (다음 필터가 동작하지 않고, WAS가 HTTP 응답을 전달해요)
 
- SwaggerConfig `@SessionAttribute` 무시 설정을 추가했어요.
    - Controller parameter에 `@SessionAttribute`를 적용한 경우, Swagger docs에 보여지지 않아요.

- MemberController 회원 정보 조회 API에 `@SessionAttribute`를 적용했어요.
    - Controller parameter에 `@SessionAttribute(MEMBER_ID) Long memberId`을 추가하면, 세션에 저장되어 있는 member_id를 꺼내어 사용할 수 있어요.
        > 인가 필터 추가할 때 세션에 저장하는 데이터를 수정할 예정이에요. 지금은 memberId만 저장하지만, 권한도 함께 저장할 예정이에요
    - 앞으로 로그인 API를 제외한 모든 Controller method의 parameter에 위와 같이 추가해서 사용하면 돼요.

- 리뷰 긴급도는 Working-day 기준으로 작성하는 걸로 통일해요~
    > ex) 금, 토, 일에 D-1로 올린 경우 월요일까지 리뷰를 기다리겠다는 의미
---

### 리뷰 받고 싶은 내용
