### PR TITLE
[SL-235] 그룹관리 API 리팩토링 및 회원별 게시글 API 수정

### DIFF
--- a/src/main/java/com/sds/actlongs/controller/channel/ChannelController.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/ChannelController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import com.sds.actlongs.controller.channel.dto.ChannelCreateRequest;
 import com.sds.actlongs.controller.channel.dto.ChannelCreateResponse;
 import com.sds.actlongs.controller.channel.dto.ChannelDeleteResponse;
+import com.sds.actlongs.controller.channel.dto.ChannelDto;
 import com.sds.actlongs.controller.channel.dto.ChannelListResponse;
 import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.model.Authentication;
@@ -42,9 +43,9 @@ public class ChannelController {
 	public ResponseEntity<ChannelListResponse> getChannelList(
 		@SessionAttribute(AUTHENTICATION) Authentication authentication,
 		final HttpServletRequest servletRequest) {
-		final List<Channel> channels = channelService.getChannelList(authentication.getMemberId(),
+		final List<ChannelDto> channelList = channelService.getChannelList(authentication.getMemberId(),
 			servletRequest.getSession());
-		return ResponseEntity.ok(ChannelListResponse.from(channels));
+		return ResponseEntity.ok(ChannelListResponse.from(channelList));
 	}
 
 	@ApiOperation(value = "그룹생성 API", notes = ""

--- a/src/main/java/com/sds/actlongs/controller/channel/ChannelController.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/ChannelController.java
@@ -26,7 +26,6 @@ import com.sds.actlongs.controller.channel.dto.ChannelCreateResponse;
 import com.sds.actlongs.controller.channel.dto.ChannelDeleteResponse;
 import com.sds.actlongs.controller.channel.dto.ChannelDto;
 import com.sds.actlongs.controller.channel.dto.ChannelListResponse;
-import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.model.Authentication;
 import com.sds.actlongs.service.channel.ChannelService;
 
@@ -41,10 +40,8 @@ public class ChannelController {
 	@ApiOperation(value = "그룹목록 조회 API", notes = "CL001: 그룹목록 조회에 성공하였습니다.")
 	@GetMapping
 	public ResponseEntity<ChannelListResponse> getChannelList(
-		@SessionAttribute(AUTHENTICATION) Authentication authentication,
 		final HttpServletRequest servletRequest) {
-		final List<ChannelDto> channelList = channelService.getChannelList(authentication.getMemberId(),
-			servletRequest.getSession());
+		final List<ChannelDto> channelList = channelService.getChannelList(servletRequest.getSession());
 		return ResponseEntity.ok(ChannelListResponse.from(channelList));
 	}
 

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelCreateResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelCreateResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.channel.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import lombok.Getter;
 
 import com.sds.actlongs.model.ResultCode;
@@ -17,11 +19,11 @@ public class ChannelCreateResponse extends ResultResponse {
 	}
 
 	private static ChannelCreateResponse succeed() {
-		return new ChannelCreateResponse(ResultCode.CHANNELCREATE_SUCCESS);
+		return new ChannelCreateResponse(CHANNELCREATE_SUCCESS);
 	}
 
 	private static ChannelCreateResponse fail() {
-		return new ChannelCreateResponse(ResultCode.CHANNELCREATE_FAILURE);
+		return new ChannelCreateResponse(CHANNELCREATE_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelCreateResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelCreateResponse.java
@@ -19,11 +19,11 @@ public class ChannelCreateResponse extends ResultResponse {
 	}
 
 	private static ChannelCreateResponse succeed() {
-		return new ChannelCreateResponse(CHANNELCREATE_SUCCESS);
+		return new ChannelCreateResponse(CREATE_CHANNEL_SUCCESS);
 	}
 
 	private static ChannelCreateResponse fail() {
-		return new ChannelCreateResponse(CHANNELCREATE_FAILURE);
+		return new ChannelCreateResponse(CREATE_CHANNEL_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelDeleteResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelDeleteResponse.java
@@ -1,15 +1,16 @@
 package com.sds.actlongs.controller.channel.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import lombok.Getter;
 
-import com.sds.actlongs.model.ResultCode;
 import com.sds.actlongs.model.ResultResponse;
 
 @Getter
 public class ChannelDeleteResponse extends ResultResponse {
 
 	public ChannelDeleteResponse() {
-		super(ResultCode.CHANNELDELETE_SUCCESS);
+		super(CHANNELDELETE_SUCCESS);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelDeleteResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelDeleteResponse.java
@@ -10,7 +10,7 @@ import com.sds.actlongs.model.ResultResponse;
 public class ChannelDeleteResponse extends ResultResponse {
 
 	public ChannelDeleteResponse() {
-		super(CHANNELDELETE_SUCCESS);
+		super(DELETE_CHANNEL_SUCCESS);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelDto.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelDto.java
@@ -1,0 +1,28 @@
+package com.sds.actlongs.controller.channel.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+import com.sds.actlongs.domain.channel.entity.Channel;
+
+@Getter
+public class ChannelDto {
+
+	@ApiModelProperty(value = "그룹PK", example = "1")
+	private final Long channelId;
+	@ApiModelProperty(value = "그룹장 회원PK", example = "11")
+	private final Long ownerId;
+	@ApiModelProperty(value = "그룹명", example = "Knox SRE")
+	private final String channelName;
+
+	public ChannelDto(Long channelId, Long ownerId, String channelName) {
+		this.channelId = channelId;
+		this.ownerId = ownerId;
+		this.channelName = channelName;
+	}
+
+	public static ChannelDto from(Channel channel) {
+		return new ChannelDto(channel.getId(), channel.getOwner().getId(), channel.getChannelName());
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelListResponse.java
@@ -28,7 +28,7 @@ public class ChannelListResponse extends ResultResponse {
 	}
 
 	public static ChannelListResponse from(List<ChannelDto> channelList) {
-		return new ChannelListResponse(CHANNELLIST_SUCCESS, channelList);
+		return new ChannelListResponse(GET_CHANNELLIST_SUCCESS, channelList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelListResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.channel.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import java.util.List;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -26,7 +28,7 @@ public class ChannelListResponse extends ResultResponse {
 	}
 
 	public static ChannelListResponse from(List<ChannelDto> channelList) {
-		return new ChannelListResponse(ResultCode.CHANNELLIST_SUCCESS, channelList);
+		return new ChannelListResponse(CHANNELLIST_SUCCESS, channelList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelListResponse.java
@@ -1,12 +1,10 @@
 package com.sds.actlongs.controller.channel.dto;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
-import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.model.ResultCode;
 import com.sds.actlongs.model.ResultResponse;
 
@@ -20,45 +18,15 @@ public class ChannelListResponse extends ResultResponse {
 		+ "{channelId: 3, ownerId: 1, name: Knox Portal},"
 		+ "]"
 	)
-	private List<JoinedChannel> channelList;
+	private final List<ChannelDto> channelList;
 
-	public ChannelListResponse(List<JoinedChannel> channelList) {
-		super(ResultCode.CHANNELLIST_SUCCESS);
+	public ChannelListResponse(ResultCode resultCode, List<ChannelDto> channelList) {
+		super(resultCode);
 		this.channelList = channelList;
 	}
 
-	public static ChannelListResponse from(List<Channel> channels) {
-		List<JoinedChannel> channelList = new ArrayList<>();
-		for (Channel channel : channels) {
-			channelList.add(JoinedChannel.of(
-				channel.getId(),
-				channel.getOwner().getId(),
-				channel.getChannelName()
-			));
-		}
-		return new ChannelListResponse(channelList);
-	}
-
-	@Getter
-	public static class JoinedChannel {
-
-		@ApiModelProperty(value = "그룹PK", example = "1")
-		private Long channelId;
-		@ApiModelProperty(value = "그룹장 회원PK", example = "11")
-		private Long ownerId;
-		@ApiModelProperty(value = "그룹명", example = "Knox SRE")
-		private String channelName;
-
-		public JoinedChannel(Long channelId, Long ownerId, String channelName) {
-			this.channelId = channelId;
-			this.ownerId = ownerId;
-			this.channelName = channelName;
-		}
-
-		public static JoinedChannel of(Long channelId, Long ownerId, String channelName) {
-			return new JoinedChannel(channelId, ownerId, channelName);
-		}
-
+	public static ChannelListResponse from(List<ChannelDto> channelList) {
+		return new ChannelListResponse(ResultCode.CHANNELLIST_SUCCESS, channelList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelMemberDto.java
+++ b/src/main/java/com/sds/actlongs/controller/channel/dto/ChannelMemberDto.java
@@ -1,0 +1,23 @@
+package com.sds.actlongs.controller.channel.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class ChannelMemberDto {
+
+	@ApiModelProperty(value = "아이디", example = "Harry")
+	private String username;
+	@ApiModelProperty(value = "PK", example = "1")
+	private Long id;
+
+	public ChannelMemberDto(Long id, String username) {
+		this.id = id;
+		this.username = username;
+	}
+
+	public static ChannelMemberDto of(Long id, String username) {
+		return new ChannelMemberDto(id, username);
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/controller/channelmember/ChannelMemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/ChannelMemberController.java
@@ -26,13 +26,13 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 
-import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
 import com.sds.actlongs.controller.channelmember.dto.ChannelLeaveResponse;
 import com.sds.actlongs.controller.channelmember.dto.MemberInviteRequest;
 import com.sds.actlongs.controller.channelmember.dto.MemberInviteResponse;
+import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
 import com.sds.actlongs.controller.channelmember.dto.MemberListResponse;
+import com.sds.actlongs.controller.channelmember.dto.MemberSearchDto;
 import com.sds.actlongs.controller.channelmember.dto.MemberSearchResponse;
-import com.sds.actlongs.domain.member.entity.Member;
 import com.sds.actlongs.model.Authentication;
 import com.sds.actlongs.service.channelmember.ChannelMemberService;
 
@@ -59,9 +59,9 @@ public class ChannelMemberController {
 		@RequestParam @NotBlank @Size(max = 20) final String keyword,
 		@SessionAttribute(AUTHENTICATION) Authentication authentication
 	) {
-		List<Member> externalMembers = channelMemberService.searchMembersNotInChannel(channelId,
+		List<MemberSearchDto> memberSearchList = channelMemberService.searchMembersNotInChannel(channelId,
 			authentication.getMemberId(), keyword);
-		return ResponseEntity.ok(MemberSearchResponse.from(externalMembers));
+		return ResponseEntity.ok(MemberSearchResponse.from(memberSearchList));
 	}
 
 	@ApiOperation(value = "그룹원 초대 API", notes = ""

--- a/src/main/java/com/sds/actlongs/controller/channelmember/ChannelMemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/ChannelMemberController.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 
-import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
+import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
 import com.sds.actlongs.controller.channelmember.dto.ChannelLeaveResponse;
 import com.sds.actlongs.controller.channelmember.dto.MemberInviteRequest;
 import com.sds.actlongs.controller.channelmember.dto.MemberInviteResponse;
@@ -48,7 +48,7 @@ public class ChannelMemberController {
 	@ApiOperation(value = "그룹원 목록 조회 API", notes = "ML001: 그룹원 목록 조회에 성공하였습니다.")
 	@GetMapping("/{groupId}")
 	public ResponseEntity<MemberListResponse> getMemberList(@PathVariable("groupId") final Long channelId) {
-		List<ChannelMemberDto> channelMemberList = channelMemberService.getMemberList(channelId);
+		List<MemberListDto> channelMemberList = channelMemberService.getMemberList(channelId);
 		return ResponseEntity.ok(MemberListResponse.from(channelMemberList));
 	}
 

--- a/src/main/java/com/sds/actlongs/controller/channelmember/ChannelMemberController.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/ChannelMemberController.java
@@ -26,12 +26,12 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 
+import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
 import com.sds.actlongs.controller.channelmember.dto.ChannelLeaveResponse;
 import com.sds.actlongs.controller.channelmember.dto.MemberInviteRequest;
 import com.sds.actlongs.controller.channelmember.dto.MemberInviteResponse;
 import com.sds.actlongs.controller.channelmember.dto.MemberListResponse;
 import com.sds.actlongs.controller.channelmember.dto.MemberSearchResponse;
-import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
 import com.sds.actlongs.domain.member.entity.Member;
 import com.sds.actlongs.model.Authentication;
 import com.sds.actlongs.service.channelmember.ChannelMemberService;
@@ -48,8 +48,8 @@ public class ChannelMemberController {
 	@ApiOperation(value = "그룹원 목록 조회 API", notes = "ML001: 그룹원 목록 조회에 성공하였습니다.")
 	@GetMapping("/{groupId}")
 	public ResponseEntity<MemberListResponse> getMemberList(@PathVariable("groupId") final Long channelId) {
-		List<ChannelMember> members = channelMemberService.getMemberList(channelId);
-		return ResponseEntity.ok(MemberListResponse.from(members));
+		List<ChannelMemberDto> channelMemberList = channelMemberService.getMemberList(channelId);
+		return ResponseEntity.ok(MemberListResponse.from(channelMemberList));
 	}
 
 	@ApiOperation(value = "회원 검색 API", notes = "MS001: 회원 검색에 성공하였습니다.")

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/ChannelLeaveResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/ChannelLeaveResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.channelmember.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import lombok.Getter;
 
 import com.sds.actlongs.model.ResultCode;
@@ -17,11 +19,11 @@ public class ChannelLeaveResponse extends ResultResponse {
 	}
 
 	private static ChannelLeaveResponse succeed() {
-		return new ChannelLeaveResponse(ResultCode.CHANNELLEAVE_SUCCESS);
+		return new ChannelLeaveResponse(CHANNELLEAVE_SUCCESS);
 	}
 
 	private static ChannelLeaveResponse fail() {
-		return new ChannelLeaveResponse(ResultCode.CHANNELLEAVE_FAILURE);
+		return new ChannelLeaveResponse(CHANNELLEAVE_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/ChannelLeaveResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/ChannelLeaveResponse.java
@@ -19,11 +19,11 @@ public class ChannelLeaveResponse extends ResultResponse {
 	}
 
 	private static ChannelLeaveResponse succeed() {
-		return new ChannelLeaveResponse(CHANNELLEAVE_SUCCESS);
+		return new ChannelLeaveResponse(LEAVE_CHANNEL_SUCCESS);
 	}
 
 	private static ChannelLeaveResponse fail() {
-		return new ChannelLeaveResponse(CHANNELLEAVE_FAILURE);
+		return new ChannelLeaveResponse(LEAVE_CHANNEL_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberInviteResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberInviteResponse.java
@@ -19,11 +19,11 @@ public class MemberInviteResponse extends ResultResponse {
 	}
 
 	private static MemberInviteResponse succeed() {
-		return new MemberInviteResponse(MEMBERINVITE_SUCCESS);
+		return new MemberInviteResponse(INVITE_MEMBER_SUCCESS);
 	}
 
 	private static MemberInviteResponse fail() {
-		return new MemberInviteResponse(MEMBERINVITE_FAILURE);
+		return new MemberInviteResponse(INVITE_MEMBER_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberInviteResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberInviteResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.channelmember.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import lombok.Getter;
 
 import com.sds.actlongs.model.ResultCode;
@@ -17,11 +19,11 @@ public class MemberInviteResponse extends ResultResponse {
 	}
 
 	private static MemberInviteResponse succeed() {
-		return new MemberInviteResponse(ResultCode.MEMBERINVITE_SUCCESS);
+		return new MemberInviteResponse(MEMBERINVITE_SUCCESS);
 	}
 
 	private static MemberInviteResponse fail() {
-		return new MemberInviteResponse(ResultCode.MEMBERINVITE_FAILURE);
+		return new MemberInviteResponse(MEMBERINVITE_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListDto.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListDto.java
@@ -1,23 +1,23 @@
-package com.sds.actlongs.controller.channel.dto;
+package com.sds.actlongs.controller.channelmember.dto;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 @Getter
-public class ChannelMemberDto {
+public class MemberListDto {
 
 	@ApiModelProperty(value = "아이디", example = "Harry")
 	private String username;
 	@ApiModelProperty(value = "PK", example = "1")
 	private Long id;
 
-	public ChannelMemberDto(Long id, String username) {
+	public MemberListDto(Long id, String username) {
 		this.id = id;
 		this.username = username;
 	}
 
-	public static ChannelMemberDto of(Long id, String username) {
-		return new ChannelMemberDto(id, username);
+	public static MemberListDto of(Long id, String username) {
+		return new MemberListDto(id, username);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
@@ -1,63 +1,32 @@
 package com.sds.actlongs.controller.channelmember.dto;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
-import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
+import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
 import com.sds.actlongs.model.ResultCode;
 import com.sds.actlongs.model.ResultResponse;
 
 @Getter
 public class MemberListResponse extends ResultResponse {
 
-	@ApiModelProperty(position = 4, value = "그룹원 목록", example = "[\n"
-		+ "    {\n"
-		+ "      \"id\": 1,\n"
-		+ "      \"username\": \"Din\"\n"
-		+ "    },\n"
-		+ "    {\n"
-		+ "      \"id\": 2,\n"
-		+ "      \"username\": \"Ari\"\n"
-		+ "    },\n"
-		+ "    {\n"
-		+ "      \"id\": 3,\n"
-		+ "      \"username\": \"Kang\"\n"
-		+ "    }\n"
-		+ "  ]")
-	private List<MemberResponse> memberList;
+	@ApiModelProperty(position = 4, value = "그룹원 목록", example = ""
+		+ "["
+		+ "{id: 1, username: Din},"
+		+ "{id: 2, username: Ari},"
+		+ "{id: 3, username: Kang},"
+		+ "]")
+	private List<ChannelMemberDto> memberList;
 
-	public MemberListResponse(List<MemberResponse> memberList) {
-		super(ResultCode.MEMBERLIST_SUCCESS);
+	public MemberListResponse(ResultCode resultCode, List<ChannelMemberDto> memberList) {
+		super(resultCode);
 		this.memberList = memberList;
 	}
 
-	public static MemberListResponse from(List<ChannelMember> channelMembers) {
-		return new MemberListResponse(channelMembers.stream()
-			.map(ChannelMember::getMember)
-			.map(member -> MemberResponse.of(member.getId(), member.getUsername()))
-			.collect(Collectors.toList()));
-	}
-
-	@Getter
-	public static class MemberResponse {
-
-		@ApiModelProperty(value = "아이디", example = "Harry")
-		private String username;
-		@ApiModelProperty(value = "PK", example = "1")
-		private Long id;
-
-		public MemberResponse(Long id, String username) {
-			this.id = id;
-			this.username = username;
-		}
-
-		public static MemberResponse of(Long id, String username) {
-			return new MemberResponse(id, username);
-		}
-
+	public static MemberListResponse from(List<ChannelMemberDto> channelMemberList) {
+		return new MemberListResponse(ResultCode.MEMBERLIST_SUCCESS, channelMemberList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.channelmember.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import java.util.List;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -25,7 +27,7 @@ public class MemberListResponse extends ResultResponse {
 	}
 
 	public static MemberListResponse from(List<MemberListDto> channelMemberList) {
-		return new MemberListResponse(ResultCode.MEMBERLIST_SUCCESS, channelMemberList);
+		return new MemberListResponse(MEMBERLIST_SUCCESS, channelMemberList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
@@ -27,7 +27,7 @@ public class MemberListResponse extends ResultResponse {
 	}
 
 	public static MemberListResponse from(List<MemberListDto> channelMemberList) {
-		return new MemberListResponse(MEMBERLIST_SUCCESS, channelMemberList);
+		return new MemberListResponse(GET_MEMBERLIST_SUCCESS, channelMemberList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberListResponse.java
@@ -5,7 +5,6 @@ import java.util.List;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
-import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
 import com.sds.actlongs.model.ResultCode;
 import com.sds.actlongs.model.ResultResponse;
 
@@ -18,14 +17,14 @@ public class MemberListResponse extends ResultResponse {
 		+ "{id: 2, username: Ari},"
 		+ "{id: 3, username: Kang},"
 		+ "]")
-	private List<ChannelMemberDto> memberList;
+	private List<MemberListDto> memberList;
 
-	public MemberListResponse(ResultCode resultCode, List<ChannelMemberDto> memberList) {
+	public MemberListResponse(ResultCode resultCode, List<MemberListDto> memberList) {
 		super(resultCode);
 		this.memberList = memberList;
 	}
 
-	public static MemberListResponse from(List<ChannelMemberDto> channelMemberList) {
+	public static MemberListResponse from(List<MemberListDto> channelMemberList) {
 		return new MemberListResponse(ResultCode.MEMBERLIST_SUCCESS, channelMemberList);
 	}
 

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchDto.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchDto.java
@@ -1,0 +1,23 @@
+package com.sds.actlongs.controller.channelmember.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class MemberSearchDto {
+
+	@ApiModelProperty(value = "회원PK", example = "1")
+	private Long memberId;
+	@ApiModelProperty(value = "아이디", example = "Harry")
+	private String username;
+
+	public MemberSearchDto(Long memberId, String username) {
+		this.memberId = memberId;
+		this.username = username;
+	}
+
+	public static MemberSearchDto of(Long memberId, String username) {
+		return new MemberSearchDto(memberId, username);
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchResponse.java
@@ -28,7 +28,7 @@ public class MemberSearchResponse extends ResultResponse {
 	}
 
 	public static MemberSearchResponse from(List<MemberSearchDto> memberSearchList) {
-		return new MemberSearchResponse(MEMBERSEARCH_SUCCESS, memberSearchList);
+		return new MemberSearchResponse(SEARCH_MEMBER_SUCCESS, memberSearchList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.channelmember.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import java.util.List;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -26,7 +28,7 @@ public class MemberSearchResponse extends ResultResponse {
 	}
 
 	public static MemberSearchResponse from(List<MemberSearchDto> memberSearchList) {
-		return new MemberSearchResponse(ResultCode.MEMBERSEARCH_SUCCESS, memberSearchList);
+		return new MemberSearchResponse(MEMBERSEARCH_SUCCESS, memberSearchList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/channelmember/dto/MemberSearchResponse.java
@@ -1,12 +1,10 @@
 package com.sds.actlongs.controller.channelmember.dto;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
-import com.sds.actlongs.domain.member.entity.Member;
 import com.sds.actlongs.model.ResultCode;
 import com.sds.actlongs.model.ResultResponse;
 
@@ -20,38 +18,15 @@ public class MemberSearchResponse extends ResultResponse {
 		+ "{ memberId: 103, username: DIN_DEAN },"
 		+ "{ memberId: 104, username: dIabcd },"
 		+ "]")
-	private List<SearchedMember> searchList;
+	private List<MemberSearchDto> memberSearchList;
 
-	public MemberSearchResponse(List<SearchedMember> searchList) {
-		super(ResultCode.MEMBERSEARCH_SUCCESS);
-		this.searchList = searchList;
+	public MemberSearchResponse(ResultCode resultCode, List<MemberSearchDto> memberSearchList) {
+		super(resultCode);
+		this.memberSearchList = memberSearchList;
 	}
 
-	public static MemberSearchResponse from(List<Member> externalMembers) {
-		List<SearchedMember> members = new ArrayList<>();
-		for (Member m : externalMembers) {
-			members.add(SearchedMember.of(m.getId(), m.getUsername()));
-		}
-		return new MemberSearchResponse(members);
-	}
-
-	@Getter
-	public static class SearchedMember {
-
-		@ApiModelProperty(value = "회원PK", example = "1")
-		private Long memberId;
-		@ApiModelProperty(value = "아이디", example = "Harry")
-		private String username;
-
-		public SearchedMember(Long memberId, String username) {
-			this.memberId = memberId;
-			this.username = username;
-		}
-
-		public static SearchedMember of(Long memberId, String username) {
-			return new SearchedMember(memberId, username);
-		}
-
+	public static MemberSearchResponse from(List<MemberSearchDto> memberSearchList) {
+		return new MemberSearchResponse(ResultCode.MEMBERSEARCH_SUCCESS, memberSearchList);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/member/dto/LoginResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/LoginResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.member.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import lombok.Getter;
 
 import com.sds.actlongs.model.ResultCode;
@@ -17,11 +19,11 @@ public class LoginResponse extends ResultResponse {
 	}
 
 	private static LoginResponse succeed() {
-		return new LoginResponse(ResultCode.LOGIN_SUCCESS);
+		return new LoginResponse(LOGIN_SUCCESS);
 	}
 
 	private static LoginResponse fail() {
-		return new LoginResponse(ResultCode.LOGIN_FAILURE);
+		return new LoginResponse(LOGIN_FAILURE);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/MemberInfoResponse.java
@@ -1,5 +1,7 @@
 package com.sds.actlongs.controller.member.dto;
 
+import static com.sds.actlongs.model.ResultCode.*;
+
 import java.util.Optional;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -25,7 +27,7 @@ public class MemberInfoResponse extends ResultResponse {
 
 	public static MemberInfoResponse of(Optional<Member> memberOptional) {
 		Member member = memberOptional.get();
-		return new MemberInfoResponse(ResultCode.MEMBERINFO_SUCCESS, member.getId(), member.getUsername());
+		return new MemberInfoResponse(MEMBERINFO_SUCCESS, member.getId(), member.getUsername());
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/MemberInfoResponse.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 import com.sds.actlongs.domain.member.entity.Member;
+import com.sds.actlongs.exception.MemberNotFoundException;
 import com.sds.actlongs.model.ResultCode;
 import com.sds.actlongs.model.ResultResponse;
 
@@ -26,8 +27,9 @@ public class MemberInfoResponse extends ResultResponse {
 	}
 
 	public static MemberInfoResponse of(Optional<Member> memberOptional) {
-		Member member = memberOptional.get();
-		return new MemberInfoResponse(MEMBERINFO_SUCCESS, member.getId(), member.getUsername());
+		return memberOptional.map(member -> new MemberInfoResponse(MEMBER_INFO_SUCCESS, member.getId(),
+				member.getUsername()))
+			.orElseThrow(() -> new MemberNotFoundException());
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/controller/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/sds/actlongs/controller/member/dto/MemberInfoResponse.java
@@ -27,7 +27,7 @@ public class MemberInfoResponse extends ResultResponse {
 	}
 
 	public static MemberInfoResponse of(Optional<Member> memberOptional) {
-		return memberOptional.map(member -> new MemberInfoResponse(MEMBER_INFO_SUCCESS, member.getId(),
+		return memberOptional.map(member -> new MemberInfoResponse(GET_MEMBER_INFO_SUCCESS, member.getId(),
 				member.getUsername()))
 			.orElseThrow(() -> new MemberNotFoundException());
 	}

--- a/src/main/java/com/sds/actlongs/domain/channel/repository/ChannelRepository.java
+++ b/src/main/java/com/sds/actlongs/domain/channel/repository/ChannelRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sds.actlongs.domain.channel.entity.Channel;
@@ -14,6 +15,7 @@ public interface ChannelRepository extends JpaRepository<Channel, Long> {
 
 	List<Channel> findByIdIn(Collection<Long> ids);
 
+	@Query("SELECT c FROM channels c WHERE c.status = 'CREATED' AND c.channelName = :channelName")
 	Optional<Channel> findByChannelName(final String channelName);
 
 	Optional<Channel> findByIdAndOwnerId(Long channelId, Long memberId);

--- a/src/main/java/com/sds/actlongs/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/sds/actlongs/domain/video/repository/VideoRepository.java
@@ -24,9 +24,9 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 
 	@Query("SELECT v "
 		+ "FROM videos v "
-		+ "INNER JOIN v.board b ON b.member.id = :memberId AND b.status = 'CREATED' "
+		+ "INNER JOIN v.board b ON b.member.id = :memberId AND b.channel.id = :channelId AND b.status = 'CREATED' "
 		+ "ORDER BY v.createdAt DESC")
-	List<Video> findByBoardMemberIdOrderByCreatedAtDesc(Long memberId);
+	List<Video> findByBoardMemberIdOrderByCreatedAtDesc(Long memberId, Long channelId);
 
 	@Query("SELECT v "
 		+ "FROM videos v "

--- a/src/main/java/com/sds/actlongs/exception/MemberNotFoundException.java
+++ b/src/main/java/com/sds/actlongs/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sds.actlongs.exception;
+
+import static com.sds.actlongs.model.ErrorCode.*;
+
+public class MemberNotFoundException extends BusinessException {
+
+	public MemberNotFoundException() {
+		super(MEMBER_NOT_FOUND);
+	}
+
+}

--- a/src/main/java/com/sds/actlongs/model/ErrorCode.java
+++ b/src/main/java/com/sds/actlongs/model/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
 	AUTHORIZATION_FAILURE(403, "E-G010", "권한이 부족합니다."),
 
 	// Member
-	MEMBERINFO_FAILURE(500, "E-M001", "회원정보 조회에 실패하였습니다."),
+	MEMBER_NOT_FOUND(500, "E-M001", "존재하지 않는 회원입니다."),
 
 	// Board
 	BOARD_NOT_MATCHED_MEMBER_FAILURE(400, "E-B001", "게시글이 존재하지 않습니다.");

--- a/src/main/java/com/sds/actlongs/model/ResultCode.java
+++ b/src/main/java/com/sds/actlongs/model/ResultCode.java
@@ -10,21 +10,21 @@ public enum ResultCode {
 	// Member
 	LOGIN_SUCCESS(200, "L001", "로그인에 성공하였습니다."),
 	LOGIN_FAILURE(200, "L002", "로그인에 실패하였습니다."),
-	MEMBER_INFO_SUCCESS(200, "MI001", "회원정보 조회에 성공하였습니다."),
-	MEMBERLIST_SUCCESS(200, "ML001", "그룹원 목록 조회에 성공하였습니다."),
-	MEMBERSEARCH_SUCCESS(200, "MS001", "회원 검색에 성공하였습니다."),
+	GET_MEMBER_INFO_SUCCESS(200, "MI001", "회원정보 조회에 성공하였습니다."),
+	GET_MEMBERLIST_SUCCESS(200, "ML001", "그룹원 목록 조회에 성공하였습니다."),
+	SEARCH_MEMBER_SUCCESS(200, "MS001", "회원 검색에 성공하였습니다."),
 
 	// Channel
-	CHANNELCREATE_SUCCESS(200, "CC001", "그룹 생성에 성공하였습니다."),
-	CHANNELCREATE_FAILURE(200, "CC002", "그룹 생성에 실패하였습니다."),
-	CHANNELLIST_SUCCESS(200, "CL001", "그룹목록 조회에 성공하였습니다."),
-	CHANNELDELETE_SUCCESS(200, "CD001", "그룹 삭제에 성공하였습니다."),
+	CREATE_CHANNEL_SUCCESS(200, "CC001", "그룹 생성에 성공하였습니다."),
+	CREATE_CHANNEL_FAILURE(200, "CC002", "그룹 생성에 실패하였습니다."),
+	GET_CHANNELLIST_SUCCESS(200, "CL001", "그룹목록 조회에 성공하였습니다."),
+	DELETE_CHANNEL_SUCCESS(200, "CD001", "그룹 삭제에 성공하였습니다."),
 
 	// ChannelMember
-	MEMBERINVITE_SUCCESS(200, "IV001", "그룹원 초대에 성공하였습니다."),
-	MEMBERINVITE_FAILURE(200, "IV002", "그룹원 초대에 실패하였습니다."),
-	CHANNELLEAVE_SUCCESS(200, "LV001", "그룹 탈퇴에 성공하였습니다."),
-	CHANNELLEAVE_FAILURE(200, "LV002", "그룹 탈퇴에 실패하였습니다."),
+	INVITE_MEMBER_SUCCESS(200, "IV001", "그룹원 초대에 성공하였습니다."),
+	INVITE_MEMBER_FAILURE(200, "IV002", "그룹원 초대에 실패하였습니다."),
+	LEAVE_CHANNEL_SUCCESS(200, "LV001", "그룹 탈퇴에 성공하였습니다."),
+	LEAVE_CHANNEL_FAILURE(200, "LV002", "그룹 탈퇴에 실패하였습니다."),
 
 	// Board
 	GET_BOARDDETAIL_SUCCESS(200, "B001", "게시글 상세정보 조회에 성공하였습니다."),

--- a/src/main/java/com/sds/actlongs/model/ResultCode.java
+++ b/src/main/java/com/sds/actlongs/model/ResultCode.java
@@ -10,7 +10,7 @@ public enum ResultCode {
 	// Member
 	LOGIN_SUCCESS(200, "L001", "로그인에 성공하였습니다."),
 	LOGIN_FAILURE(200, "L002", "로그인에 실패하였습니다."),
-	MEMBERINFO_SUCCESS(200, "MI001", "회원정보 조회에 성공하였습니다."),
+	MEMBER_INFO_SUCCESS(200, "MI001", "회원정보 조회에 성공하였습니다."),
 	MEMBERLIST_SUCCESS(200, "ML001", "그룹원 목록 조회에 성공하였습니다."),
 	MEMBERSEARCH_SUCCESS(200, "MS001", "회원 검색에 성공하였습니다."),
 

--- a/src/main/java/com/sds/actlongs/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/board/BoardServiceImpl.java
@@ -121,7 +121,7 @@ public class BoardServiceImpl implements BoardService {
 			.stream()
 			.map(channelMember -> {
 				final List<Video> videoList = videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(
-					channelMember.getMember().getId());
+					channelMember.getMember().getId(), channelId);
 				return new MemberBoardsDto(channelMember.getMember().getUsername(), videoList);
 			})
 			.collect(Collectors.toList());

--- a/src/main/java/com/sds/actlongs/service/channel/ChannelService.java
+++ b/src/main/java/com/sds/actlongs/service/channel/ChannelService.java
@@ -8,7 +8,7 @@ import com.sds.actlongs.controller.channel.dto.ChannelDto;
 
 public interface ChannelService {
 
-	List<ChannelDto> getChannelList(final Long memberId, final HttpSession session);
+	List<ChannelDto> getChannelList(final HttpSession session);
 
 	boolean createChannel(final String channelName, final Long ownerId, final HttpSession session);
 

--- a/src/main/java/com/sds/actlongs/service/channel/ChannelService.java
+++ b/src/main/java/com/sds/actlongs/service/channel/ChannelService.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import com.sds.actlongs.domain.channel.entity.Channel;
+import com.sds.actlongs.controller.channel.dto.ChannelDto;
 
 public interface ChannelService {
 
-	List<Channel> getChannelList(final Long memberId, final HttpSession session);
+	List<ChannelDto> getChannelList(final Long memberId, final HttpSession session);
 
 	boolean createChannel(final String channelName, final Long ownerId, final HttpSession session);
 

--- a/src/main/java/com/sds/actlongs/service/channel/ChannelServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/channel/ChannelServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.sds.actlongs.controller.channel.dto.ChannelDto;
 import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.domain.channel.repository.ChannelRepository;
 import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
@@ -32,14 +33,16 @@ public class ChannelServiceImpl implements ChannelService {
 	private final ChannelMemberRepository channelMemberRepository;
 
 	@Override
-	public List<Channel> getChannelList(final Long memberId, final HttpSession session) {
+	public List<ChannelDto> getChannelList(final Long memberId, final HttpSession session) {
 		Set<Long> channelIds = ((Authentication)session.getAttribute(
 			SessionConstants.AUTHENTICATION))
 			.getChannelAuthorityMap()
 			.keySet();
 
-		return channelRepository.findByIdIn(channelIds);
-		// return channelMemberRepository.findAllFetchMemberAndChannelByMemberId(memberId);
+		return channelRepository.findByIdIn(channelIds)
+			.stream()
+			.map(channel -> ChannelDto.from(channel))
+			.collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/com/sds/actlongs/service/channel/ChannelServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/channel/ChannelServiceImpl.java
@@ -1,7 +1,6 @@
 package com.sds.actlongs.service.channel;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -21,8 +20,7 @@ import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
 import com.sds.actlongs.domain.channelmember.repository.ChannelMemberRepository;
 import com.sds.actlongs.domain.member.entity.Member;
 import com.sds.actlongs.domain.member.repository.MemberRepository;
-import com.sds.actlongs.model.Authentication;
-import com.sds.actlongs.util.SessionConstants;
+import com.sds.actlongs.util.session.SessionManage;
 
 @Service
 @RequiredArgsConstructor
@@ -31,41 +29,33 @@ public class ChannelServiceImpl implements ChannelService {
 	private final MemberRepository memberRepository;
 	private final ChannelRepository channelRepository;
 	private final ChannelMemberRepository channelMemberRepository;
+	private final SessionManage sessionManage;
 
 	@Override
-	public List<ChannelDto> getChannelList(final Long memberId, final HttpSession session) {
-		Set<Long> channelIds = ((Authentication)session.getAttribute(
-			SessionConstants.AUTHENTICATION))
-			.getChannelAuthorityMap()
-			.keySet();
-
+	public List<ChannelDto> getChannelList(final HttpSession session) {
+		final Set<Long> channelIds = sessionManage.getAccessibleChannelList(session).keySet();
 		return channelRepository.findByIdIn(channelIds)
 			.stream()
-			.map(channel -> ChannelDto.from(channel))
+			.map(ChannelDto::from)
 			.collect(Collectors.toList());
 	}
 
 	@Override
 	@Transactional
 	public boolean createChannel(final String channelName, final Long ownerId, final HttpSession session) {
-		Optional<Channel> channelOptional = channelRepository.findByChannelName(channelName);
+		final Optional<Channel> channelOptional = channelRepository.findByChannelName(channelName);
 		if (channelOptional.isPresent()) {
 			return false;
 		}
-		Optional<Member> memberOptional = memberRepository.findById(ownerId);
+		final Optional<Member> memberOptional = memberRepository.findById(ownerId);
 		if (memberOptional.isEmpty()) {
 			return false;
 		}
 
-		Member owner = memberOptional.get();
-		Channel channel = channelRepository.save(Channel.createNewChannel(channelName, owner));
+		final Member owner = memberOptional.get();
+		final Channel channel = channelRepository.save(Channel.createNewChannel(channelName, owner));
 		channelMemberRepository.save(ChannelMember.registerMemberToChannel(owner, channel));
-
-		Map<Long, Authentication.ChannelRoles> map = ((Authentication)session.getAttribute(
-			SessionConstants.AUTHENTICATION))
-			.getChannelAuthorityMap();
-		map.put(channel.getId(), Authentication.ChannelRoles.OWNER);
-		session.setAttribute(SessionConstants.AUTHENTICATION, new Authentication(ownerId, map));
+		sessionManage.addOwnedChannel(session, channel.getId(), ownerId);
 		return true;
 	}
 
@@ -75,15 +65,7 @@ public class ChannelServiceImpl implements ChannelService {
 		final Channel channel = channelRepository.findByIdAndOwnerId(channelId, memberId)
 			.orElseThrow(EntityNotFoundException::new);
 		channel.delete();
-
-		Map<Long, Authentication.ChannelRoles> map = ((Authentication)session.getAttribute(
-			SessionConstants.AUTHENTICATION))
-			.getChannelAuthorityMap()
-			.entrySet()
-			.stream()
-			.filter(e -> !e.getKey().equals(channelId))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-		session.setAttribute(SessionConstants.AUTHENTICATION, new Authentication(memberId, map));
+		sessionManage.deleteChannel(session, channelId, memberId);
 	}
 
 }

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberService.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberService.java
@@ -5,13 +5,14 @@ import java.util.List;
 import javax.servlet.http.HttpSession;
 
 import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
+import com.sds.actlongs.controller.channelmember.dto.MemberSearchDto;
 import com.sds.actlongs.domain.member.entity.Member;
 
 public interface ChannelMemberService {
 
 	List<MemberListDto> getMemberList(final Long channelId);
 
-	List<Member> searchMembersNotInChannel(final Long channelId, final Long memberId, final String keyword);
+	List<MemberSearchDto> searchMembersNotInChannel(final Long channelId, final Long memberId, final String keyword);
 
 	boolean inviteMember(final Long channelId, final Long memberId);
 

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberService.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberService.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
+import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
 import com.sds.actlongs.domain.member.entity.Member;
 
 public interface ChannelMemberService {
 
-	List<ChannelMemberDto> getMemberList(final Long channelId);
+	List<MemberListDto> getMemberList(final Long channelId);
 
 	List<Member> searchMembersNotInChannel(final Long channelId, final Long memberId, final String keyword);
 

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberService.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberService.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
+import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
 import com.sds.actlongs.domain.member.entity.Member;
 
 public interface ChannelMemberService {
 
-	List<ChannelMember> getMemberList(final Long channelId);
+	List<ChannelMemberDto> getMemberList(final Long channelId);
 
 	List<Member> searchMembersNotInChannel(final Long channelId, final Long memberId, final String keyword);
 

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
+import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
 import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.domain.channel.repository.ChannelRepository;
 import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
@@ -30,12 +31,16 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 	private final MemberRepository memberRepository;
 
 	@Override
-	public List<ChannelMember> getMemberList(final Long channelId) {
+	public List<ChannelMemberDto> getMemberList(final Long channelId) {
 		final Optional<Channel> optionalChannel = channelRepository.findById(channelId);
 		if (optionalChannel.isEmpty() || optionalChannel.get().getStatus().equals(Channel.Status.DELETED)) {
 			throw new EntityNotFoundException();
 		}
-		return channelMemberRepository.findAllFetchMemberUsernameByChannelId(channelId);
+		return channelMemberRepository.findAllFetchMemberUsernameByChannelId(channelId)
+			.stream()
+			.map(ChannelMember::getMember)
+			.map(member -> ChannelMemberDto.of(member.getId(), member.getUsername()))
+			.collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 
 import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
+import com.sds.actlongs.controller.channelmember.dto.MemberSearchDto;
 import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.domain.channel.repository.ChannelRepository;
 import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
@@ -44,7 +45,8 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 	}
 
 	@Override
-	public List<Member> searchMembersNotInChannel(final Long channelId, final Long memberId, final String keyword) {
+	public List<MemberSearchDto> searchMembersNotInChannel(final Long channelId, final Long memberId,
+		final String keyword) {
 		List<Member> membersSearched = memberRepository.findAllByUsernameStartsWith(keyword)
 			.stream()
 			.filter(m -> !m.getId().equals(memberId))
@@ -57,7 +59,11 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 			.collect(Collectors.toList());
 
 		membersSearched.removeAll(membersBelongsToChannel);
-		return membersSearched;
+
+		return membersSearched
+			.stream()
+			.map(member -> MemberSearchDto.of(member.getId(), member.getUsername()))
+			.collect(Collectors.toList());
 	}
 
 	@Override

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
@@ -1,7 +1,6 @@
 package com.sds.actlongs.service.channelmember;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -20,8 +19,7 @@ import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
 import com.sds.actlongs.domain.channelmember.repository.ChannelMemberRepository;
 import com.sds.actlongs.domain.member.entity.Member;
 import com.sds.actlongs.domain.member.repository.MemberRepository;
-import com.sds.actlongs.model.Authentication;
-import com.sds.actlongs.util.SessionConstants;
+import com.sds.actlongs.util.session.SessionManage;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +28,7 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 	private final ChannelMemberRepository channelMemberRepository;
 	private final ChannelRepository channelRepository;
 	private final MemberRepository memberRepository;
+	private final SessionManage sessionManage;
 
 	@Override
 	public List<MemberListDto> getMemberList(final Long channelId) {
@@ -93,15 +92,7 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 
 		final ChannelMember channelMember = channelMemberOptional.get();
 		channelMemberRepository.deleteById(channelMember.getId());
-
-		Map<Long, Authentication.ChannelRoles> filteredMap = ((Authentication)session.getAttribute(
-			SessionConstants.AUTHENTICATION))
-			.getChannelAuthorityMap()
-			.entrySet()
-			.stream()
-			.filter(e -> !e.getKey().equals(channelId))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-		session.setAttribute(SessionConstants.AUTHENTICATION, new Authentication(memberId, filteredMap));
+		sessionManage.deleteChannel(session, channelId, memberId);
 		return true;
 	}
 

--- a/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/channelmember/ChannelMemberServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
-import com.sds.actlongs.controller.channel.dto.ChannelMemberDto;
+import com.sds.actlongs.controller.channelmember.dto.MemberListDto;
 import com.sds.actlongs.domain.channel.entity.Channel;
 import com.sds.actlongs.domain.channel.repository.ChannelRepository;
 import com.sds.actlongs.domain.channelmember.entity.ChannelMember;
@@ -31,7 +31,7 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 	private final MemberRepository memberRepository;
 
 	@Override
-	public List<ChannelMemberDto> getMemberList(final Long channelId) {
+	public List<MemberListDto> getMemberList(final Long channelId) {
 		final Optional<Channel> optionalChannel = channelRepository.findById(channelId);
 		if (optionalChannel.isEmpty() || optionalChannel.get().getStatus().equals(Channel.Status.DELETED)) {
 			throw new EntityNotFoundException();
@@ -39,7 +39,7 @@ public class ChannelMemberServiceImpl implements ChannelMemberService {
 		return channelMemberRepository.findAllFetchMemberUsernameByChannelId(channelId)
 			.stream()
 			.map(ChannelMember::getMember)
-			.map(member -> ChannelMemberDto.of(member.getId(), member.getUsername()))
+			.map(member -> MemberListDto.of(member.getId(), member.getUsername()))
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/sds/actlongs/util/session/SessionManage.java
+++ b/src/main/java/com/sds/actlongs/util/session/SessionManage.java
@@ -1,0 +1,17 @@
+package com.sds.actlongs.util.session;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import com.sds.actlongs.model.Authentication;
+
+public interface SessionManage {
+
+	Map<Long, Authentication.ChannelRoles> getAccessibleChannelList(final HttpSession session);
+
+	void addOwnedChannel(final HttpSession session, final Long channelId, final Long ownerId);
+
+	void deleteChannel(final HttpSession session, final Long channelId, final Long memberId);
+
+}

--- a/src/main/java/com/sds/actlongs/util/session/SessionManageImpl.java
+++ b/src/main/java/com/sds/actlongs/util/session/SessionManageImpl.java
@@ -1,0 +1,45 @@
+package com.sds.actlongs.util.session;
+
+import static com.sds.actlongs.model.Authentication.ChannelRoles.*;
+import static com.sds.actlongs.util.SessionConstants.*;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+import com.sds.actlongs.model.Authentication;
+import com.sds.actlongs.util.SessionConstants;
+
+@Component
+@Getter
+public class SessionManageImpl implements SessionManage {
+
+	@Override
+	public Map<Long, Authentication.ChannelRoles> getAccessibleChannelList(HttpSession session) {
+		return ((Authentication)session.getAttribute(AUTHENTICATION))
+			.getChannelAuthorityMap();
+	}
+
+	@Override
+	public void addOwnedChannel(final HttpSession session, final Long channelId, final Long ownerId) {
+		Map<Long, Authentication.ChannelRoles> map = this.getAccessibleChannelList(session);
+		map.put(channelId, OWNER);
+		session.setAttribute(AUTHENTICATION, new Authentication(ownerId, map));
+	}
+
+	@Override
+	public void deleteChannel(final HttpSession session, final Long channelId, final Long memberId) {
+		final Map<Long, Authentication.ChannelRoles> map = this.getAccessibleChannelList(session)
+			.entrySet()
+			.stream()
+			.filter(e -> !e.getKey().equals(channelId))
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+		session.setAttribute(SessionConstants.AUTHENTICATION, new Authentication(memberId, map));
+	}
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -31,9 +31,12 @@ VALUES (2, 1, '2023-06-09 17:46:10', '2023-06-09 17:46:10'),
        (7, 3, '2023-06-09 17:46:10', '2023-06-09 17:46:10');
 
 INSERT INTO boards (member_id, channel_id, title, description, status, created_at, updated_at)
-VALUES (2, 1, 'title1', 'description1', 'CREATED', '2023-06-09 17:46:10', '2023-06-09 17:46:10');
+VALUES (2, 1, 'title1', 'description1', 'CREATED', '2023-06-09 17:46:10', '2023-06-09 17:46:10'),
+       (2, 2, 'title2', 'description2', 'CREATED', '2023-06-09 17:46:10', '2023-06-09 17:46:10');
 
 INSERT INTO videos (board_id, thumbnail_image_uuid, thumbnail_image_type, video_uuid, video_type, playing_time,
                     created_at, updated_at)
 VALUES (1, 'c0c5afcaaad24d91bfb777440ef3bc12', 'PNG', 'c0c5afcaaad24d91bfb777440ef3bc12', 'MP4', '00:00:26',
-        '2023-06-09 17:46:10', '2023-06-09 17:46:10');
+        '2023-06-09 17:46:10', '2023-06-09 17:46:10'),
+       (2, 'c0c5afcaaad24d91bfb777440ef3bc08', 'PNG', 'c0c5afcaaad24d91bfb777440ef3bc08', 'MP4', '00:00:26',
+       '2023-06-09 17:46:10', '2023-06-09 17:46:10');

--- a/src/test/java/com/sds/actlongs/service/board/BoardServiceImplTest.java
+++ b/src/test/java/com/sds/actlongs/service/board/BoardServiceImplTest.java
@@ -202,9 +202,9 @@ class BoardServiceImplTest {
 			Arrays.asList(channelMember1, channelMember2));
 		given(videoRepository.findByBoardChannelIdOrderByCreatedAtDesc(channel.getId())).willReturn(
 			Arrays.asList(video2, video1));
-		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member1.getId())).willReturn(
+		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member1.getId(), channel.getId())).willReturn(
 			List.of(video1));
-		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member2.getId())).willReturn(
+		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member2.getId(), channel.getId())).willReturn(
 			List.of(video2));
 
 		//when


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-0

---

### 변경사항

* stream을 활용하여 그룹관리 API 서비스 리팩토링
* 그룹 조회, 생성, 삭제 시 세션에 접근하는 로직을 sessionManage로 추출
* 회원별 게시글 조회 시 해당 그룹에 올린 동영상만 나오도록 쿼리문 수정

