### PR TITLE
[SL-243] 회원별 동영상 목록 조회 쿼리문 수정

### DIFF
--- a/src/main/java/com/sds/actlongs/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/sds/actlongs/domain/video/repository/VideoRepository.java
@@ -30,9 +30,10 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 
 	@Query("SELECT v "
 		+ "FROM videos v "
-		+ "INNER JOIN v.board b ON b.member.id = :memberId AND b.status IN ('UPLOADING','COMPLETED') "
+		+ "INNER JOIN v.board b ON b.member.id = :memberId AND b.channel.id = :channelId "
+		+ "AND b.status IN ('UPLOADING','COMPLETED') "
 		+ "ORDER BY v.createdAt DESC")
-	List<Video> findByBoardMemberIdOrderByCreatedAtDesc(Long memberId);
+	List<Video> findByBoardMemberIdOrderByCreatedAtDesc(Long memberId, Long channelId);
 
 	@Query("SELECT v "
 		+ "FROM videos v "

--- a/src/main/java/com/sds/actlongs/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/sds/actlongs/service/board/BoardServiceImpl.java
@@ -106,7 +106,7 @@ public class BoardServiceImpl implements BoardService {
 			.stream()
 			.map(channelMember -> {
 				final List<Video> videoList = videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(
-					channelMember.getMember().getId());
+					channelMember.getMember().getId(), channelId);
 				return new MemberBoardsDto(channelMember.getMember().getUsername(), videoList);
 			})
 			.collect(Collectors.toList());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -31,9 +31,12 @@ VALUES (2, 1, '2023-06-09 17:46:10', '2023-06-09 17:46:10'),
        (7, 3, '2023-06-09 17:46:10', '2023-06-09 17:46:10');
 
 INSERT INTO boards (member_id, channel_id, title, description, status, created_at, updated_at)
-VALUES (2, 1, 'title1', 'description1', 'CREATED', '2023-06-09 17:46:10', '2023-06-09 17:46:10');
+VALUES (2, 1, 'title1', 'description1', 'COMPLETED', '2023-06-09 17:46:10', '2023-06-09 17:46:10'),
+       (2, 2, 'title2', 'description2', 'COMPLETED', '2023-06-09 17:46:10', '2023-06-09 17:46:10');
 
 INSERT INTO videos (board_id, thumbnail_image_uuid, thumbnail_image_type, video_uuid, video_type, playing_time,
                     created_at, updated_at)
 VALUES (1, 'c0c5afcaaad24d91bfb777440ef3bc12', 'PNG', 'c0c5afcaaad24d91bfb777440ef3bc12', 'MP4', '00:00:26',
+        '2023-06-09 17:46:10', '2023-06-09 17:46:10'),
+       (2, 'c0c5afcaaad24d91bfb777440ef3bc08', 'PNG', 'c0c5afcaaad24d91bfb777440ef3bc08', 'MP4', '00:00:26',
         '2023-06-09 17:46:10', '2023-06-09 17:46:10');

--- a/src/test/java/com/sds/actlongs/service/board/BoardServiceImplTest.java
+++ b/src/test/java/com/sds/actlongs/service/board/BoardServiceImplTest.java
@@ -202,9 +202,9 @@ class BoardServiceImplTest {
 			Arrays.asList(channelMember1, channelMember2));
 		given(videoRepository.findByBoardChannelIdOrderByCreatedAtDesc(channel.getId())).willReturn(
 			Arrays.asList(video2, video1));
-		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member1.getId())).willReturn(
+		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member1.getId(), channel.getId())).willReturn(
 			List.of(video1));
-		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member2.getId())).willReturn(
+		given(videoRepository.findByBoardMemberIdOrderByCreatedAtDesc(member2.getId(), channel.getId())).willReturn(
 			List.of(video2));
 
 		//when


### PR DESCRIPTION
### 리뷰 요청
- [ ] 🙋 꼭 리뷰를 받고 싶어요!
- 리뷰 긴급도: D-0

---

### 변경사항

게시글 목록 조회 API 요청 시 회원별로 게시글 목록을 response body에 담아주는데,
현재 채널 외의 게시글까지 모두 조회되는 오류를 수정하기 위해 쿼리문에 채널ID 조건 추가
